### PR TITLE
Av/91 no note content bug fix

### DIFF
--- a/lib/home.dart
+++ b/lib/home.dart
@@ -125,6 +125,7 @@ class HomeState extends State<Home> with SingleTickerProviderStateMixin {
                     ),
                     FormBuilderTextField(
                       name: 'noteTitle',
+                      autofocus: true,
                       decoration: const InputDecoration(
                         labelText: 'Note Title',
                         labelStyle: TextStyle(

--- a/lib/home.dart
+++ b/lib/home.dart
@@ -185,56 +185,63 @@ class HomeState extends State<Home> with SingleTickerProviderStateMixin {
                       // String noteTitle =
                       //     formData['noteTitle'].split(' ').join('_');
 
-                      String noteTitle =
-                          formData['noteTitle'].replaceAll('\n', '');
+                      if (noteText.trim() != '') {
+                        String noteTitle =
+                            formData['noteTitle'].replaceAll('\n', '');
 
-                      // Get date and time
-                      String dateTimeStr = DateFormat('yyyyMMddTHHmmss')
-                          .format(DateTime.now())
-                          .toString();
+                        // Get date and time
+                        String dateTimeStr = DateFormat('yyyyMMddTHHmmss')
+                            .format(DateTime.now())
+                            .toString();
 
-                      // Encrypt note text using created time as the key
-                      // av: 20250519 - We need to encrypt the note text because
-                      // at the moment rdflib cannot parse multiline text with
-                      // # (hash) values in them.
-                      String encNoteText = encryptVal(noteText, dateTimeStr);
+                        // Encrypt note text using created time as the key
+                        // av: 20250519 - We need to encrypt the note text because
+                        // at the moment rdflib cannot parse multiline text with
+                        // # (hash) values in them.
+                        String encNoteText = encryptVal(noteText, dateTimeStr);
 
-                      // Create note file name
-                      // String noteFileName =
-                      //     '$noteFileNamePrefix$noteTitle-$dateTimeStr.ttl';
-                      String noteFileName =
-                          '$noteFileNamePrefix$dateTimeStr.ttl';
+                        // Create note file name
+                        // String noteFileName =
+                        //     '$noteFileNamePrefix$noteTitle-$dateTimeStr.ttl';
+                        String noteFileName =
+                            '$noteFileNamePrefix$dateTimeStr.ttl';
 
-                      // Create TTL body for note
-                      final noteTTLStr = genNoteTTLStr(
-                          dateTimeStr, dateTimeStr, noteTitle, encNoteText);
+                        // Create TTL body for note
+                        final noteTTLStr = genNoteTTLStr(
+                            dateTimeStr, dateTimeStr, noteTitle, encNoteText);
 
-                      final createNoteStatus = await writePod(
-                        noteFileName,
-                        noteTTLStr,
-                        context,
-                        Home(),
-                        //encrypted: false, // save in plain text for now
-                      );
-
-                      if (createNoteStatus == SolidFunctionCallStatus.success) {
-                        //Navigator.pop(context);
-
-                        Navigator.pushAndRemoveUntil(
+                        final createNoteStatus = await writePod(
+                          noteFileName,
+                          noteTTLStr,
                           context,
-                          MaterialPageRoute(
-                            builder: (context) => AppScreen(
-                              title: topBarTitle,
-                              childPage: Home(),
-                            ),
-                          ),
-                          (Route<dynamic> route) =>
-                              false, // This predicate ensures all previous routes are removed
+                          Home(),
+                          //encrypted: false, // save in plain text for now
                         );
+
+                        if (createNoteStatus ==
+                            SolidFunctionCallStatus.success) {
+                          //Navigator.pop(context);
+
+                          Navigator.pushAndRemoveUntil(
+                            context,
+                            MaterialPageRoute(
+                              builder: (context) => AppScreen(
+                                title: topBarTitle,
+                                childPage: Home(),
+                              ),
+                            ),
+                            (Route<dynamic> route) =>
+                                false, // This predicate ensures all previous routes are removed
+                          );
+                        } else {
+                          Navigator.pop(context);
+                          showErrDialog(context,
+                              'Failed to store the note file in your POD. Try again!');
+                        }
                       } else {
                         Navigator.pop(context);
-                        showErrDialog(context,
-                            'Failed to store the note file in your POD. Try again!');
+                        showErrDialog(
+                            context, 'Please enter some note content.');
                       }
                     } else {
                       showErrDialog(context,

--- a/lib/widgets/markdown_editor.dart
+++ b/lib/widgets/markdown_editor.dart
@@ -50,7 +50,7 @@ Container markdownEditor(
             SizedBox(
               width: cardWidth,
               child: TextField(
-                autofocus: true,
+                // autofocus: true,
                 controller: textController,
                 focusNode: focusNode,
                 keyboardType: TextInputType.multiline,


### PR DESCRIPTION
## Pull Request Details

## What issue does this PR address

- Include an error dialog when the user press save note without andy note content
- By default focus on note title

- Link to associated issue: https://github.com/anusii/notepod/issues/91 and https://github.com/anusii/notepod/issues/124

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [x] Pre-exisiting lint errors noted: [HERE]
- [x] Integration test `make qtest.tmp` screenshot included in issue
- [x] Tested on device:
  - [ ] Linux
  - [ ] MacOS
  - [x] Windows
  - [ ] Android
  - [ ] iOS
  - [ ] Web
- [ ] Added software engineer reviewer
- [ ] Approved by one software engineer reviewer
- [ ] Approved by team leader

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev
