### PR TITLE
specify list item extent to improve listview efficiency

### DIFF
--- a/lib/constants/app.dart
+++ b/lib/constants/app.dart
@@ -38,6 +38,8 @@ const kDefaultPadding = 20.0;
 const double normalLoadingScreenHeight = 200.0;
 const double buttonBorderRadius = 5;
 const double standardSpace = 20.0;
+const double listItemHeight = 88.0;
+const double sharedListItemHeight = 108.0;
 
 double screenWidth(BuildContext context) => MediaQuery.of(context).size.width;
 double screenHeight(BuildContext context) => MediaQuery.of(context).size.height;

--- a/lib/notes/list_notes.dart
+++ b/lib/notes/list_notes.dart
@@ -113,6 +113,7 @@ class _ListNotesState extends State<ListNotes> {
             child: ListView.builder(
                 padding: const EdgeInsets.all(10),
                 itemCount: _foundNotes.length,
+                itemExtent: listItemHeight,
                 itemBuilder: (context, index) => Card(
                       shape: const RoundedRectangleBorder(
                           borderRadius: BorderRadius.all(Radius.circular(5))),

--- a/lib/shared_notes/list_shared_notes.dart
+++ b/lib/shared_notes/list_shared_notes.dart
@@ -63,6 +63,7 @@ class _ListSharedNotesState extends State<ListSharedNotes> {
             child: ListView.builder(
                 padding: const EdgeInsets.all(10),
                 itemCount: sharedNotesMap.length,
+                itemExtent: sharedListItemHeight,
                 itemBuilder: (context, index) => Card(
                       shape: const RoundedRectangleBorder(
                           borderRadius: BorderRadius.all(Radius.circular(5))),


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- The loading time for loading the note lists in NOTE LIST and SHARED NOTE LIST is slow. This is probably largely due to querying the pod. This PR makes a minor improvement to listview rendering efficiency for longer note lists by specifying the list item height. https://docs.flutter.dev/cookbook/lists/long-lists
If note lists became very long, slivers could be used, however not expected to be needed as yet.

However the note list load times remain slow. This PR doesn't improve load times enough t address the issue.

## Associated Issue

- This PR relates to issue #139 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

- [ ] Screenshots included in linked issue #
- [x] Changes adhere to the [style and coding guidelines](https://survivor.togaware.com/gnulinux/flutter-style.html)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] The update contains no confidential information
- [x] The update has no duplicated content
- [x] No lint check errors are related to these changes (`make prep` or `flutter analyze lib`)
- [ ] Integration test `dart test` output or screenshot included in issue #
- [x] I tested the PR on these devices:
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] MacOS
  - [ ] Windows
  - [x] Web
- [ ] I have identified two reviewers - only one reviewer selected as trivial change
- [ ] The PR has been approved by two reviewers

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the this branch
- [ ] Resolve any conflicts
- [ ] Add a one line summary into the CHANGELOG.md
- [ ] Push to the git repository and review
- [ ] Merge the PR into dev
