### PR TITLE
moved repeated copies of commented alternative markdown editor

### DIFF
--- a/lib/notes/edit_note.dart
+++ b/lib/notes/edit_note.dart
@@ -142,29 +142,6 @@ class EditNoteState extends State<EditNote>
             height: 10,
           ),
           markdownEditor(context, _textController!, _focusNode, data),
-
-          // Container(
-          //   padding: const EdgeInsets.all(10),
-          //   child: MarkdownAutoPreview(
-          //     controller: _textController,
-          //     decoration: InputDecoration(
-          //       hintText: 'Input markdown text',
-          //     ),
-          //     emojiConvert: true,
-          //     hintText: 'Tap here to start writing a note!',
-          //     // maxLines: 10,
-          //     // minLines: 1,
-          //     // expands: true,
-          //   ),
-          //   // SplittedMarkdownFormField(
-          //   //   controller: _textController,
-          //   //   markdownSyntax: '## Headline',
-          //   //   decoration: const InputDecoration(
-          //   //     hintText: 'Editable text',
-          //   //   ),
-          //   //   emojiConvert: true,
-          //   // )
-          // ),
           const SizedBox(
             height: 20,
           ),

--- a/lib/notes/new_note.dart
+++ b/lib/notes/new_note.dart
@@ -158,19 +158,6 @@ class NewNoteState extends State<NewNote> with SingleTickerProviderStateMixin {
             height: 10,
           ),
           markdownEditor(context, _textController!, _focusNode, data),
-
-          // av: 20250604 - The following code is from the package
-          // markdown_editor_plus. The current version of this gives some errors
-          // when inputting different styles such as checkboxes.
-          // SplittedMarkdownFormField(
-          //   controller: _textController,
-          //   markdownSyntax: '## Headline',
-          //   decoration: const InputDecoration(
-          //     hintText: 'Editable text',
-          //   ),
-          //   emojiConvert: true,
-          // ),
-
           const SizedBox(
             height: 20,
           ),

--- a/lib/shared_notes/edit_shared_note.dart
+++ b/lib/shared_notes/edit_shared_note.dart
@@ -144,16 +144,6 @@ class EditSharedNoteState extends State<EditSharedNote>
             height: 10,
           ),
           markdownEditor(context, _textController!, _focusNode, data),
-          // Container(
-          //     padding: const EdgeInsets.all(10),
-          //     child: SplittedMarkdownFormField(
-          //       controller: _textController,
-          //       markdownSyntax: '## Headline',
-          //       decoration: const InputDecoration(
-          //         hintText: 'Editable text',
-          //       ),
-          //       emojiConvert: true,
-          //     )),
           const SizedBox(
             height: 20,
           ),

--- a/lib/widgets/markdown_editor.dart
+++ b/lib/widgets/markdown_editor.dart
@@ -86,4 +86,30 @@ Container markdownEditor(
       ],
     ),
   );
+
+  // // av: 20250604 - Alternative markdown editor option using
+  // // markdown_editor_plus. The current version of this gives some errors
+  // // when inputting different styles such as checkboxes.
+  // return Container(
+  //   padding: const EdgeInsets.all(10),
+  //   child: MarkdownAutoPreview(
+  //     controller: _textController,
+  //     decoration: InputDecoration(
+  //       hintText: 'Input markdown text',
+  //     ),
+  //     emojiConvert: true,
+  //     hintText: 'Tap here to start writing a note!',
+  //     // maxLines: 10,
+  //     // minLines: 1,
+  //     // expands: true,
+  //   ),
+  //   // SplittedMarkdownFormField(
+  //   //   controller: _textController,
+  //   //   markdownSyntax: '## Headline',
+  //   //   decoration: const InputDecoration(
+  //   //     hintText: 'Editable text',
+  //   //   ),
+  //   //   emojiConvert: true,
+  //   // )
+  // );
 }


### PR DESCRIPTION
… to markdownEditor()

# Pull Request Details

## What issue does this PR address

V minor change: Moved the commented note about alternative markdown editor to markdownEditor() for safekeeping and removed repeated copies.

## Associated Issue

- This PR relates to issue #152

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Yes on macos - no change to expected behaviour

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

- [ ] Screenshots included in linked issue #
- [x] Changes adhere to the [style and coding guidelines](https://survivor.togaware.com/gnulinux/flutter-style.html)
- [ ] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] The update contains no confidential information
- [x] The update has no duplicated content
- [x] No lint check errors are related to these changes (`make prep` or `flutter analyze lib`)
- [ ] Integration test `dart test` output or screenshot included in issue #
- [x] I tested the PR on these devices:
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] MacOS
  - [ ] Windows
  - [ ] Web
- [ ] I have identified two reviewers
- [ ] The PR has been approved by two reviewers

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the this branch
- [ ] Resolve any conflicts
- [ ] Add a one line summary into the CHANGELOG.md
- [ ] Push to the git repository and review
- [ ] Merge the PR into dev
