### PR TITLE
Added separator between metadata and note content

### DIFF
--- a/lib/constants/app.dart
+++ b/lib/constants/app.dart
@@ -65,6 +65,11 @@ const titleStyle = TextStyle(
   fontWeight: FontWeight.bold,
 );
 
+// Text style for metadata
+const metadataTextStyle = TextStyle(
+  fontSize: 14,
+);
+
 // Text style for list sort buttons
 const smallTextStyle = TextStyle(
   fontSize: 12,
@@ -73,3 +78,6 @@ const smallTextStyle = TextStyle(
 // Titles for nav widgets to pages
 const String myNotesTitle = 'My Notes';
 const String sharedNotesTitle = 'Shared Notes';
+
+// EdgeInsets for metadata block on view notes
+const EdgeInsets metadataPadding = EdgeInsets.fromLTRB(15, 5, 10, 0);

--- a/lib/nav_drawer.dart
+++ b/lib/nav_drawer.dart
@@ -132,13 +132,11 @@ class NavDrawer extends StatelessWidget {
                     );
                   },
                 ),
-                // ListTile(
-                //   leading: const Icon(Icons.share_rounded),
-                //   title: const Text('Note Sharing'),
-                //   onTap: () => {Navigator.of(context).pop()},
-                // ),
                 ListTile(
-                  leading: const Icon(Icons.file_open_outlined),
+                  // 20250717 jm: Alternate icons for Shared Notes
+                  // leading: const Icon(Icons.share_rounded),
+                  // leading: const Icon(Icons.file_open_outlined),
+                  leading: const Icon(Icons.groups),
                   title: const Text(sharedNotesTitle),
                   onTap: () {
                     Navigator.pushAndRemoveUntil(

--- a/lib/notes/view_note.dart
+++ b/lib/notes/view_note.dart
@@ -38,8 +38,8 @@ import 'package:notepod/notes/list_notes_screen.dart';
 import 'package:notepod/notes/share_note.dart';
 import 'package:notepod/widgets/loading_animation.dart';
 import 'package:notepod/widgets/note_back_button.dart';
-import 'package:notepod/widgets/note_display_metadata.dart';
 import 'package:notepod/widgets/note_display_markdown.dart';
+import 'package:notepod/widgets/note_display_metadata.dart';
 
 class ViewNote extends StatefulWidget {
   final Map noteData;

--- a/lib/notes/view_note.dart
+++ b/lib/notes/view_note.dart
@@ -37,9 +37,9 @@ import 'package:notepod/constants/turtle_structures.dart';
 import 'package:notepod/notes/edit_note.dart';
 import 'package:notepod/notes/list_notes_screen.dart';
 import 'package:notepod/notes/share_note.dart';
-import 'package:notepod/utils/misc.dart';
 import 'package:notepod/widgets/loading_animation.dart';
 import 'package:notepod/widgets/note_back_button.dart';
+import 'package:notepod/widgets/note_display_metadata.dart';
 
 class ViewNote extends StatefulWidget {
   final Map noteData;
@@ -78,38 +78,9 @@ class _ViewNoteState extends State<ViewNote> {
             ),
           ],
         ),
-        Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Flexible(
-              child: Container(
-                padding: const EdgeInsets.fromLTRB(15, 5, 10, 0),
-                child: Text(
-                  'Created on: ${getDateTimeStr(noteData[createdDateTimePred])}',
-                  style: const TextStyle(
-                    fontSize: 14,
-                  ),
-                ),
-              ),
-            ),
-          ],
-        ),
-        Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Flexible(
-              child: Container(
-                padding: const EdgeInsets.fromLTRB(15, 5, 10, 10),
-                child: Text(
-                  'Last modified on: ${getDateTimeStr(noteData[modifiedDateTimePred])}',
-                  style: const TextStyle(
-                    fontSize: 14,
-                  ),
-                ),
-              ),
-            ),
-          ],
-        ),
+        // Display note metadata
+        NoteDisplayMetadata(data: noteData, shared: false),
+        Divider(),
         Expanded(
           child: SizedBox(
             child: Container(

--- a/lib/shared_notes/view_shared_note.dart
+++ b/lib/shared_notes/view_shared_note.dart
@@ -21,7 +21,7 @@
 // You should have received a copy of the GNU General Public License along with
 // this program.  If not, see <https://www.gnu.org/licenses/>.
 ///
-/// Authors: Anushka Vidanage, Graham Williams
+/// Authors: Anushka Vidanage, Graham Williams, Jess Moore
 
 library;
 
@@ -32,8 +32,8 @@ import 'package:markdown_widget/markdown_widget.dart';
 import 'package:notepod/constants/turtle_structures.dart';
 import 'package:notepod/shared_notes/shared_note_controls.dart';
 import 'package:notepod/shared_notes/shared_notes_screen.dart';
-import 'package:notepod/utils/misc.dart';
 import 'package:notepod/widgets/note_back_button.dart';
+import 'package:notepod/widgets/note_display_metadata.dart';
 
 class ViewSharedNote extends StatefulWidget {
   final Map fullNoteData;
@@ -74,86 +74,9 @@ class _ViewSharedNoteState extends State<ViewSharedNote> {
             ),
           ],
         ),
-        Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Flexible(
-              child: Container(
-                padding: const EdgeInsets.fromLTRB(15, 5, 10, 0),
-                child: Text(
-                  'Created on: ${getDateTimeStr(sharedNoteContent[createdDateTimePred])}',
-                  style: const TextStyle(
-                    fontSize: 14,
-                  ),
-                ),
-              ),
-            ),
-          ],
-        ),
-        Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Flexible(
-              child: Container(
-                padding: const EdgeInsets.fromLTRB(15, 5, 10, 0),
-                child: Text(
-                  'Last modified on: ${getDateTimeStr(sharedNoteContent[modifiedDateTimePred])}',
-                  style: const TextStyle(
-                    fontSize: 14,
-                  ),
-                ),
-              ),
-            ),
-          ],
-        ),
-        Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Flexible(
-              child: Container(
-                padding: const EdgeInsets.fromLTRB(15, 5, 10, 0),
-                child: Text(
-                  'Owner: ${sharedNoteInfo[noteOwner]}',
-                  style: const TextStyle(
-                    fontSize: 14,
-                  ),
-                ),
-              ),
-            ),
-          ],
-        ),
-        Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Flexible(
-              child: Container(
-                padding: const EdgeInsets.fromLTRB(15, 5, 10, 0),
-                child: Text(
-                  'Shared by: ${sharedNoteInfo[permissionGranter]}',
-                  style: const TextStyle(
-                    fontSize: 14,
-                  ),
-                ),
-              ),
-            ),
-          ],
-        ),
-        Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Flexible(
-              child: Container(
-                padding: const EdgeInsets.fromLTRB(15, 5, 10, 10),
-                child: Text(
-                  'Permissions: ${sharedNoteInfo[permissionList]}',
-                  style: const TextStyle(
-                    fontSize: 14,
-                  ),
-                ),
-              ),
-            ),
-          ],
-        ),
+        // Display note metadata
+        NoteDisplayMetadata(data: widget.fullNoteData, shared: true),
+        Divider(),
         Expanded(
           child: SizedBox(
             child: Container(

--- a/lib/shared_notes/view_shared_note.dart
+++ b/lib/shared_notes/view_shared_note.dart
@@ -31,8 +31,8 @@ import 'package:notepod/constants/turtle_structures.dart';
 import 'package:notepod/shared_notes/shared_note_controls.dart';
 import 'package:notepod/shared_notes/shared_notes_screen.dart';
 import 'package:notepod/widgets/note_back_button.dart';
-import 'package:notepod/widgets/note_display_metadata.dart';
 import 'package:notepod/widgets/note_display_markdown.dart';
+import 'package:notepod/widgets/note_display_metadata.dart';
 
 class ViewSharedNote extends StatefulWidget {
   final Map fullNoteData;

--- a/lib/widgets/note_display_metadata.dart
+++ b/lib/widgets/note_display_metadata.dart
@@ -26,8 +26,8 @@ library;
 
 import 'package:flutter/material.dart';
 
-import 'package:notepod/constants/turtle_structures.dart';
 import 'package:notepod/constants/app.dart';
+import 'package:notepod/constants/turtle_structures.dart';
 import 'package:notepod/utils/misc.dart';
 
 // Displays note metadata

--- a/lib/widgets/note_display_metadata.dart
+++ b/lib/widgets/note_display_metadata.dart
@@ -1,0 +1,143 @@
+/// DESCRIPTION
+///
+// Time-stamp: <Friday 2025-07-17 20:39:20 +1000 Jess Moore>
+///
+/// Copyright (C) 2025, Software Innovation Institute, ANU
+///
+/// Licensed under the GNU General Public License, Version 3 (the "License");
+///
+/// License: https://www.gnu.org/licenses/gpl-3.0.en.html
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later
+// version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+// details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <https://www.gnu.org/licenses/>.
+///
+/// Authors: Jess Moore
+library;
+
+import 'package:flutter/material.dart';
+
+import 'package:notepod/constants/turtle_structures.dart';
+import 'package:notepod/constants/app.dart';
+import 'package:notepod/utils/misc.dart';
+
+// Displays note metadata
+
+class NoteDisplayMetadata extends StatelessWidget {
+  final Map data;
+  final bool shared;
+
+  const NoteDisplayMetadata({
+    Key? key,
+    required this.data,
+    required this.shared,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    Map noteInfo = {};
+    Map noteContent = {};
+    if (shared) {
+      noteInfo = data['sharedNoteInfo'];
+      noteContent = data['sharedNoteContent'];
+    } else {
+      noteContent = data;
+    }
+
+    return Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Flexible(
+                child: Container(
+                  padding: metadataPadding,
+                  child: Text(
+                    'Created on: ${getDateTimeStr(noteContent[createdDateTimePred])}',
+                    style: metadataTextStyle,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Flexible(
+                child: Container(
+                  padding: metadataPadding,
+                  child: Text(
+                    'Last modified on: ${getDateTimeStr(noteContent[modifiedDateTimePred])}',
+                    style: metadataTextStyle,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          // Show sharing metadata if shared external file
+          if (shared) accessInfo(noteInfo),
+          SizedBox(height: 10),
+        ]);
+  }
+}
+
+// Metadata block containing access info (owner, provider, access list)
+Widget accessInfo(noteInfo) {
+  return Column(
+    children: [
+      Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Flexible(
+            child: Container(
+              padding: metadataPadding,
+              child: Text(
+                'Owner: ${noteInfo[noteOwner]}',
+                style: metadataTextStyle,
+              ),
+            ),
+          ),
+        ],
+      ),
+      Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Flexible(
+            child: Container(
+              padding: metadataPadding,
+              child: Text(
+                'Shared by: ${noteInfo[permissionGranter]}',
+                style: metadataTextStyle,
+              ),
+            ),
+          ),
+        ],
+      ),
+      Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Flexible(
+            child: Container(
+              padding: metadataPadding,
+              child: Text(
+                'Permissions: ${noteInfo[permissionList]}',
+                style: metadataTextStyle,
+              ),
+            ),
+          ),
+        ],
+      ),
+    ],
+  );
+}


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- Used a simple Divider() to separate metadata and note content in view note and view shared note
- Removed duplicated code 
- Applied the new icon for Shared Notes in app bar to nav drawer

## Associated Issue

- This PR relates to issue #155 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested on macos

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

- [x] Screenshots included in linked issue #
- [x] Changes adhere to the [style and coding guidelines](https://survivor.togaware.com/gnulinux/flutter-style.html)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] The update contains no confidential information
- [x] The update has no duplicated content
- [x] No lint check errors are related to these changes (`make prep` or `flutter analyze lib`)
- [ ] Integration test `dart test` output or screenshot included in issue #
- [ ] I tested the PR on these devices:
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] MacOS
  - [ ] Windows
  - [ ] Web
- [ ] I have identified two reviewers
- [ ] The PR has been approved by two reviewers

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the this branch
- [ ] Resolve any conflicts
- [ ] Add a one line summary into the CHANGELOG.md
- [ ] Push to the git repository and review
- [ ] Merge the PR into dev
