### PR TITLE
VIEWs: move singlechildscrollview to around note, metadata and title

### DIFF
--- a/lib/notes/view_note.dart
+++ b/lib/notes/view_note.dart
@@ -59,203 +59,205 @@ class _ViewNoteState extends State<ViewNote> {
   Widget build(BuildContext context) {
     Map noteData = widget.noteData;
 
-    return Column(
-      children: <Widget>[
-        Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Flexible(
-              child: Container(
-                padding: const EdgeInsets.fromLTRB(15, 10, 10, 5),
-                child: Text(
-                  noteData[noteTitlePred],
-                  style: const TextStyle(
-                    fontWeight: FontWeight.bold,
-                    fontSize: 22,
-                  ),
-                ),
-              ),
-            ),
-          ],
-        ),
-        // Display note metadata
-        NoteDisplayMetadata(data: noteData, shared: false),
-        Divider(),
-        // Display markdown note content
-        noteDisplayMarkdown(noteData[noteContentPred]),
-        Padding(
-          padding: const EdgeInsets.all(8.0),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.end,
+    return SingleChildScrollView(
+      child: Column(
+        children: <Widget>[
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              ElevatedButton.icon(
-                icon: const Icon(
-                  Icons.share,
-                  color: Colors.white,
-                ),
-                onPressed: () async {
-                  // Get note file path
-                  String noteFilePath =
-                      '$noteFileNamePrefix${noteData[createdDateTimePred]}.ttl';
-
-                  // redirect
-                  Navigator.pushAndRemoveUntil(
-                    context,
-                    MaterialPageRoute(
-                        builder: (context) => AppScreen(
-                              title: topBarTitle,
-                              childPage: ShareNote(
-                                noteData: noteData,
-                                noteFilePath: noteFilePath,
-                              ),
-                            )),
-                    (Route<dynamic> route) =>
-                        false, // This predicate ensures all previous routes are removed
-                  );
-                },
-                style: ElevatedButton.styleFrom(
-                  foregroundColor: darkBlue,
-                  backgroundColor: lightBlue, // foreground
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 15,
-                  ),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(20),
-                  ),
-                ),
-                label: const Text(
-                  'SHARE',
-                  style: TextStyle(color: Colors.white),
-                ),
-              ),
-              const SizedBox(
-                width: 5,
-              ),
-              ElevatedButton.icon(
-                icon: const Icon(
-                  Icons.edit,
-                  color: Colors.white,
-                ),
-                onPressed: () async {
-                  Navigator.pushAndRemoveUntil(
-                    context,
-                    MaterialPageRoute(
-                      builder: (context) => AppScreen(
-                        title: topBarTitle,
-                        childPage: EditNote(
-                          noteData: noteData,
-                        ),
-                      ),
+              Flexible(
+                child: Container(
+                  padding: const EdgeInsets.fromLTRB(15, 10, 10, 5),
+                  child: Text(
+                    noteData[noteTitlePred],
+                    style: const TextStyle(
+                      fontWeight: FontWeight.bold,
+                      fontSize: 22,
                     ),
-                    (Route<dynamic> route) =>
-                        false, // This predicate ensures all previous routes are removed
-                  );
-                },
-                style: ElevatedButton.styleFrom(
-                  foregroundColor: darkGreen,
-                  backgroundColor: lightGreen, // foreground
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 15,
-                  ),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(20),
                   ),
                 ),
-                label: const Text(
-                  'EDIT',
-                  style: TextStyle(color: Colors.white),
-                ),
               ),
-              const SizedBox(
-                width: 5,
-              ),
-
-              /// Delete function: Following function is commented out
-              ElevatedButton.icon(
-                icon: const Icon(
-                  Icons.delete,
-                  color: Colors.white,
-                ),
-                onPressed: () {
-                  showDialog(
-                    context: context,
-                    builder: (BuildContext ctx) {
-                      return AlertDialog(
-                        title: const Text('Please Confirm'),
-                        content: const Text(
-                          'Are you sure you want to delete this note?',
-                        ),
-                        actions: [
-                          // The "Yes" button
-                          TextButton(
-                            onPressed: () async {
-                              showAnimationDialog(
-                                context,
-                                17,
-                                'Deleting the note!',
-                                false,
-                              );
-
-                              // Delete file
-                              // Create note file path
-                              String noteFilePath =
-                                  '$mainResDir/$dataDir/$noteFileNamePrefix${noteData[createdDateTimePred]}.ttl';
-
-                              // Call solid delete file function
-                              await deleteFile(noteFilePath);
-
-                              Navigator.pushAndRemoveUntil(
-                                context,
-                                MaterialPageRoute(
-                                    builder: (context) => AppScreen(
-                                          title: topBarTitle,
-                                          childPage: ListNotesScreen(),
-                                        )),
-                                (Route<dynamic> route) =>
-                                    false, // This predicate ensures all previous routes are removed
-                              );
-                            },
-                            child: const Text('Yes'),
-                          ),
-                          TextButton(
-                            onPressed: () {
-                              // Close the dialog
-                              Navigator.of(context).pop();
-                            },
-                            child: const Text('No'),
-                          ),
-                        ],
-                      );
-                    },
-                  );
-                },
-                style: ElevatedButton.styleFrom(
-                  foregroundColor: darkRed,
-                  backgroundColor: lightRed, // foreground
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 15,
-                  ),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(20),
-                  ),
-                ),
-                label: const Text(
-                  'DELETE',
-                  style: TextStyle(color: Colors.white),
-                ),
-              ),
-              const SizedBox(
-                width: 5,
-              ),
-
-              NoteBackButton(childPage: ListNotesScreen()),
             ],
           ),
-        ),
-        const SizedBox(
-          height: 10,
-        ),
-      ],
+          // Display note metadata
+          NoteDisplayMetadata(data: noteData, shared: false),
+          Divider(),
+          // Display markdown note content
+          noteDisplayMarkdown(noteData[noteContentPred]),
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                ElevatedButton.icon(
+                  icon: const Icon(
+                    Icons.share,
+                    color: Colors.white,
+                  ),
+                  onPressed: () async {
+                    // Get note file path
+                    String noteFilePath =
+                        '$noteFileNamePrefix${noteData[createdDateTimePred]}.ttl';
+
+                    // redirect
+                    Navigator.pushAndRemoveUntil(
+                      context,
+                      MaterialPageRoute(
+                          builder: (context) => AppScreen(
+                                title: topBarTitle,
+                                childPage: ShareNote(
+                                  noteData: noteData,
+                                  noteFilePath: noteFilePath,
+                                ),
+                              )),
+                      (Route<dynamic> route) =>
+                          false, // This predicate ensures all previous routes are removed
+                    );
+                  },
+                  style: ElevatedButton.styleFrom(
+                    foregroundColor: darkBlue,
+                    backgroundColor: lightBlue, // foreground
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 15,
+                    ),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(20),
+                    ),
+                  ),
+                  label: const Text(
+                    'SHARE',
+                    style: TextStyle(color: Colors.white),
+                  ),
+                ),
+                const SizedBox(
+                  width: 5,
+                ),
+                ElevatedButton.icon(
+                  icon: const Icon(
+                    Icons.edit,
+                    color: Colors.white,
+                  ),
+                  onPressed: () async {
+                    Navigator.pushAndRemoveUntil(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => AppScreen(
+                          title: topBarTitle,
+                          childPage: EditNote(
+                            noteData: noteData,
+                          ),
+                        ),
+                      ),
+                      (Route<dynamic> route) =>
+                          false, // This predicate ensures all previous routes are removed
+                    );
+                  },
+                  style: ElevatedButton.styleFrom(
+                    foregroundColor: darkGreen,
+                    backgroundColor: lightGreen, // foreground
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 15,
+                    ),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(20),
+                    ),
+                  ),
+                  label: const Text(
+                    'EDIT',
+                    style: TextStyle(color: Colors.white),
+                  ),
+                ),
+                const SizedBox(
+                  width: 5,
+                ),
+
+                /// Delete function: Following function is commented out
+                ElevatedButton.icon(
+                  icon: const Icon(
+                    Icons.delete,
+                    color: Colors.white,
+                  ),
+                  onPressed: () {
+                    showDialog(
+                      context: context,
+                      builder: (BuildContext ctx) {
+                        return AlertDialog(
+                          title: const Text('Please Confirm'),
+                          content: const Text(
+                            'Are you sure you want to delete this note?',
+                          ),
+                          actions: [
+                            // The "Yes" button
+                            TextButton(
+                              onPressed: () async {
+                                showAnimationDialog(
+                                  context,
+                                  17,
+                                  'Deleting the note!',
+                                  false,
+                                );
+
+                                // Delete file
+                                // Create note file path
+                                String noteFilePath =
+                                    '$mainResDir/$dataDir/$noteFileNamePrefix${noteData[createdDateTimePred]}.ttl';
+
+                                // Call solid delete file function
+                                await deleteFile(noteFilePath);
+
+                                Navigator.pushAndRemoveUntil(
+                                  context,
+                                  MaterialPageRoute(
+                                      builder: (context) => AppScreen(
+                                            title: topBarTitle,
+                                            childPage: ListNotesScreen(),
+                                          )),
+                                  (Route<dynamic> route) =>
+                                      false, // This predicate ensures all previous routes are removed
+                                );
+                              },
+                              child: const Text('Yes'),
+                            ),
+                            TextButton(
+                              onPressed: () {
+                                // Close the dialog
+                                Navigator.of(context).pop();
+                              },
+                              child: const Text('No'),
+                            ),
+                          ],
+                        );
+                      },
+                    );
+                  },
+                  style: ElevatedButton.styleFrom(
+                    foregroundColor: darkRed,
+                    backgroundColor: lightRed, // foreground
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 15,
+                    ),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(20),
+                    ),
+                  ),
+                  label: const Text(
+                    'DELETE',
+                    style: TextStyle(color: Colors.white),
+                  ),
+                ),
+                const SizedBox(
+                  width: 5,
+                ),
+
+                NoteBackButton(childPage: ListNotesScreen()),
+              ],
+            ),
+          ),
+          const SizedBox(
+            height: 10,
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/shared_notes/view_shared_note.dart
+++ b/lib/shared_notes/view_shared_note.dart
@@ -54,55 +54,57 @@ class _ViewSharedNoteState extends State<ViewSharedNote> {
     Map sharedNoteContent = widget.fullNoteData['sharedNoteContent'];
     List accessList = sharedNoteInfo[permissionList].split(',');
 
-    return Column(
-      children: <Widget>[
-        Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Flexible(
-              child: Container(
-                padding: const EdgeInsets.fromLTRB(15, 10, 10, 5),
-                child: Text(
-                  sharedNoteContent[noteTitlePred],
-                  style: const TextStyle(
-                    fontWeight: FontWeight.bold,
-                    fontSize: 22,
+    return SingleChildScrollView(
+      child: Column(
+        children: <Widget>[
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Flexible(
+                child: Container(
+                  padding: const EdgeInsets.fromLTRB(15, 10, 10, 5),
+                  child: Text(
+                    sharedNoteContent[noteTitlePred],
+                    style: const TextStyle(
+                      fontWeight: FontWeight.bold,
+                      fontSize: 22,
+                    ),
                   ),
                 ),
               ),
-            ),
-          ],
-        ),
-        // Display note metadata
-        NoteDisplayMetadata(data: widget.fullNoteData, shared: true),
-        Divider(),
-        // Display markdown note content
-        noteDisplayMarkdown(sharedNoteContent[noteContentPred]),
-        Padding(
-          padding: const EdgeInsets.all(8.0),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.end,
-            children: [
-              if (accessList.contains('control')) ...[
-                shareNote(context, widget.fullNoteData),
-                const SizedBox(
-                  width: 5,
-                ),
-              ],
-              if (accessList.contains('write')) ...[
-                editNote(context, widget.fullNoteData),
-                const SizedBox(
-                  width: 5,
-                ),
-              ],
-              NoteBackButton(childPage: SharedNotesScreen()),
             ],
           ),
-        ),
-        const SizedBox(
-          height: 10,
-        ),
-      ],
+          // Display note metadata
+          NoteDisplayMetadata(data: widget.fullNoteData, shared: true),
+          Divider(),
+          // Display markdown note content
+          noteDisplayMarkdown(sharedNoteContent[noteContentPred]),
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                if (accessList.contains('control')) ...[
+                  shareNote(context, widget.fullNoteData),
+                  const SizedBox(
+                    width: 5,
+                  ),
+                ],
+                if (accessList.contains('write')) ...[
+                  editNote(context, widget.fullNoteData),
+                  const SizedBox(
+                    width: 5,
+                  ),
+                ],
+                NoteBackButton(childPage: SharedNotesScreen()),
+              ],
+            ),
+          ),
+          const SizedBox(
+            height: 10,
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/widgets/note_display_markdown.dart
+++ b/lib/widgets/note_display_markdown.dart
@@ -30,27 +30,25 @@ import 'package:flutter/material.dart';
 import 'package:markdown_widget/markdown_widget.dart';
 
 // Displays note content with MarkdownBlock()
-Expanded noteDisplayMarkdown(
+// Expanded noteDisplayMarkdown(
+Container noteDisplayMarkdown(
   String data,
 ) {
-  return Expanded(
-    child: SizedBox(
-      child: Container(
-          alignment: Alignment.topLeft,
-          padding: const EdgeInsets.all(10),
-          child: SingleChildScrollView(child: MarkdownBlock(data: data))),
-      // 20250717 jm Alt method retained for reference
-      // MarkdownParse(
-      //   data: noteData[noteContentPred],
-      //   // onTapHastag: (String name, String match) {
-      //   //   // name => hashtag
-      //   //   // match => #hashtag
-      //   // },
-      //   // onTapMention: (String name, String match) {
-      //   //   // name => mention
-      //   //   // match => #mention
-      //   // },
-      // )
-    ),
-  );
+  return Container(
+      alignment: Alignment.topLeft,
+      padding: const EdgeInsets.all(10),
+      // child: SingleChildScrollView(child: MarkdownBlock(data: data))),
+      child: MarkdownBlock(data: data));
+  // 20250717 jm Alt method retained for reference
+  // MarkdownParse(
+  //   data: noteData[noteContentPred],
+  //   // onTapHastag: (String name, String match) {
+  //   //   // name => hashtag
+  //   //   // match => #hashtag
+  //   // },
+  //   // onTapMention: (String name, String match) {
+  //   //   // name => mention
+  //   //   // match => #mention
+  //   // },
+  // )
 }


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- the difficulty of grab and scrolling the markdown block of long narrow notes


## Associated Issue

- This PR relates to issue #166 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

- [x] Screenshots included in linked issue #
- [x] Changes adhere to the [style and coding guidelines](https://survivor.togaware.com/gnulinux/flutter-style.html)
- [ ] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] The update contains no confidential information
- [ ] The update has no duplicated content
- [x] No lint check errors are related to these changes (`make prep` or `flutter analyze lib`)
- [ ] Integration test `dart test` output or screenshot included in issue #
- [x] I tested the PR on these devices:
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] MacOS
  - [ ] Windows
  - [ ] Web
- [ ] I have identified two reviewers
- [ ] The PR has been approved by two reviewers

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the this branch
- [ ] Resolve any conflicts
- [ ] Add a one line summary into the CHANGELOG.md
- [ ] Push to the git repository and review
- [ ] Merge the PR into dev
