### PR TITLE
make action buttons always visible on view/edit pages

### DIFF
--- a/lib/notes/view_note.dart
+++ b/lib/notes/view_note.dart
@@ -27,9 +27,6 @@ library;
 
 import 'package:flutter/material.dart';
 
-// import 'package:notepod/app_screen.dart';
-// import 'package:notepod/constants/app.dart';
-// import 'package:notepod/constants/colours.dart';
 import 'package:notepod/constants/turtle_structures.dart';
 import 'package:notepod/notes/edit_note.dart';
 import 'package:notepod/notes/list_notes_screen.dart';
@@ -63,70 +60,81 @@ class _ViewNoteState extends State<ViewNote> {
     String noteFilePath =
         '$noteFileNamePrefix${noteData[createdDateTimePred]}.ttl';
 
-    return SingleChildScrollView(
-      child: Column(
-        children: <Widget>[
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Flexible(
-                child: Container(
-                  padding: const EdgeInsets.fromLTRB(15, 10, 10, 5),
-                  child: Text(
-                    noteData[noteTitlePred],
-                    style: const TextStyle(
-                      fontWeight: FontWeight.bold,
-                      fontSize: 22,
+    return Column(
+      children: <Widget>[
+        Expanded(
+          child: SingleChildScrollView(
+            child: Column(
+              children: <Widget>[
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Flexible(
+                      child: Container(
+                        padding: const EdgeInsets.fromLTRB(15, 10, 10, 5),
+                        child: Text(
+                          noteData[noteTitlePred],
+                          style: const TextStyle(
+                            fontWeight: FontWeight.bold,
+                            fontSize: 22,
+                          ),
+                        ),
+                      ),
                     ),
-                  ),
+                  ],
                 ),
-              ),
-            ],
-          ),
-          // Display note metadata
-          NoteDisplayMetadata(data: noteData, shared: false),
-          Divider(),
-          // Display markdown note content
-          noteDisplayMarkdown(noteData[noteContentPred]),
-          Padding(
-            padding: const EdgeInsets.all(8.0),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.end,
-              children: [
-                // Share button
-                NoteShareButton(
-                    childPage: ShareNote(
-                  noteData: noteData,
-                  noteFilePath: noteFilePath,
-                )),
-                const SizedBox(
-                  width: 5,
-                ),
-                // Edit button
-                NoteEditButton(
-                  childPage: EditNote(
-                    noteData: noteData,
-                  ),
-                ),
-                const SizedBox(
-                  width: 5,
-                ),
-
-                /// Delete button
-                NoteDelButton(noteData: noteData, shared: false),
-                const SizedBox(
-                  width: 5,
-                ),
-                // Back button
-                NoteBackButton(childPage: ListNotesScreen()),
+                // Display note metadata
+                NoteDisplayMetadata(data: noteData, shared: false),
+                Divider(),
+                // Display markdown note content
+                noteDisplayMarkdown(noteData[noteContentPred]),
               ],
             ),
           ),
-          const SizedBox(
-            height: 10,
-          ),
-        ],
-      ),
+        ),
+        // Action buttons - always visible
+        Column(
+          children: <Widget>[
+            Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  // Share button
+                  NoteShareButton(
+                      childPage: ShareNote(
+                    noteData: noteData,
+                    noteFilePath: noteFilePath,
+                  )),
+                  const SizedBox(
+                    width: 5,
+                  ),
+                  // Edit button
+                  NoteEditButton(
+                    childPage: EditNote(
+                      noteData: noteData,
+                    ),
+                  ),
+                  const SizedBox(
+                    width: 5,
+                  ),
+
+                  /// Delete button
+                  NoteDelButton(noteData: noteData, shared: false),
+                  const SizedBox(
+                    width: 5,
+                  ),
+                  // Back button
+                  NoteBackButton(childPage: ListNotesScreen()),
+                ],
+              ),
+            ),
+            const SizedBox(
+              height: 10,
+            ),
+          ],
+        ),
+      ],
     );
   }
 }

--- a/lib/notes/view_note.dart
+++ b/lib/notes/view_note.dart
@@ -35,8 +35,8 @@ import 'package:notepod/widgets/note_back_button.dart';
 import 'package:notepod/widgets/note_del_button.dart';
 import 'package:notepod/widgets/note_display_markdown.dart';
 import 'package:notepod/widgets/note_display_metadata.dart';
-import 'package:notepod/widgets/note_share_button.dart';
 import 'package:notepod/widgets/note_edit_button.dart';
+import 'package:notepod/widgets/note_share_button.dart';
 
 class ViewNote extends StatefulWidget {
   final Map noteData;

--- a/lib/shared_notes/non_readable_note.dart
+++ b/lib/shared_notes/non_readable_note.dart
@@ -33,7 +33,6 @@ import 'package:notepod/shared_notes/share_external_note.dart';
 import 'package:notepod/shared_notes/shared_notes_screen.dart';
 import 'package:notepod/widgets/msg_card.dart';
 import 'package:notepod/widgets/note_back_button.dart';
-// import 'package:notepod/widgets/note_del_button.dart';
 import 'package:notepod/widgets/note_share_button.dart';
 
 class NonReadableNote extends StatefulWidget {

--- a/lib/shared_notes/view_shared_note.dart
+++ b/lib/shared_notes/view_shared_note.dart
@@ -57,68 +57,79 @@ class _ViewSharedNoteState extends State<ViewSharedNote> {
     Map sharedNoteContent = widget.fullNoteData['sharedNoteContent'];
     List accessList = sharedNoteInfo[permissionList].split(',');
 
-    return SingleChildScrollView(
-      child: Column(
-        children: <Widget>[
-          Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Flexible(
-                child: Container(
-                  padding: const EdgeInsets.fromLTRB(15, 10, 10, 5),
-                  child: Text(
-                    sharedNoteContent[noteTitlePred],
-                    style: const TextStyle(
-                      fontWeight: FontWeight.bold,
-                      fontSize: 22,
+    return Column(
+      children: [
+        Expanded(
+          child: SingleChildScrollView(
+            child: Column(
+              children: <Widget>[
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Flexible(
+                      child: Container(
+                        padding: const EdgeInsets.fromLTRB(15, 10, 10, 5),
+                        child: Text(
+                          sharedNoteContent[noteTitlePred],
+                          style: const TextStyle(
+                            fontWeight: FontWeight.bold,
+                            fontSize: 22,
+                          ),
+                        ),
+                      ),
                     ),
-                  ),
+                  ],
                 ),
-              ),
-            ],
-          ),
-          // Display note metadata
-          NoteDisplayMetadata(data: widget.fullNoteData, shared: true),
-          Divider(),
-          // Display markdown note content
-          noteDisplayMarkdown(sharedNoteContent[noteContentPred]),
-          Padding(
-            padding: const EdgeInsets.all(8.0),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.end,
-              children: [
-                // Share if control access
-                if (accessList.contains('control')) ...[
-                  NoteShareButton(
-                    childPage: ShareExternalNote(
-                      // noteMetaData: noteMetaData,
-                      fullNoteData: widget.fullNoteData,
-                    ),
-                  ),
-                  const SizedBox(
-                    width: 5,
-                  ),
-                ],
-                // Edit if write access
-                if (accessList.contains('write')) ...[
-                  NoteEditButton(
-                      childPage: EditSharedNote(
-                    fullNoteData: widget.fullNoteData,
-                  )),
-                  const SizedBox(
-                    width: 5,
-                  ),
-                  // Back
-                  NoteBackButton(childPage: SharedNotesScreen()),
-                ],
+                // Display note metadata
+                NoteDisplayMetadata(data: widget.fullNoteData, shared: true),
+                Divider(),
+                // Display markdown note content
+                noteDisplayMarkdown(sharedNoteContent[noteContentPred]),
               ],
             ),
           ),
-          const SizedBox(
-            height: 10,
-          ),
-        ],
-      ),
+        ),
+        // Action buttons - always visible
+        Column(
+          children: <Widget>[
+            Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  // Share if control access
+                  if (accessList.contains('control')) ...[
+                    NoteShareButton(
+                      childPage: ShareExternalNote(
+                        // noteMetaData: noteMetaData,
+                        fullNoteData: widget.fullNoteData,
+                      ),
+                    ),
+                    const SizedBox(
+                      width: 5,
+                    ),
+                  ],
+                  // Edit if write access
+                  if (accessList.contains('write')) ...[
+                    NoteEditButton(
+                        childPage: EditSharedNote(
+                      fullNoteData: widget.fullNoteData,
+                    )),
+                    const SizedBox(
+                      width: 5,
+                    ),
+                    // Back
+                    NoteBackButton(childPage: SharedNotesScreen()),
+                  ],
+                ],
+              ),
+            ),
+            const SizedBox(
+              height: 10,
+            ),
+          ],
+        ),
+      ],
     );
   }
 }

--- a/lib/shared_notes/view_shared_note.dart
+++ b/lib/shared_notes/view_shared_note.dart
@@ -28,14 +28,14 @@ library;
 import 'package:flutter/material.dart';
 
 import 'package:notepod/constants/turtle_structures.dart';
-import 'package:notepod/shared_notes/share_external_note.dart';
 import 'package:notepod/shared_notes/edit_shared_note.dart';
+import 'package:notepod/shared_notes/share_external_note.dart';
 import 'package:notepod/shared_notes/shared_notes_screen.dart';
 import 'package:notepod/widgets/note_back_button.dart';
 import 'package:notepod/widgets/note_display_markdown.dart';
 import 'package:notepod/widgets/note_display_metadata.dart';
-import 'package:notepod/widgets/note_share_button.dart';
 import 'package:notepod/widgets/note_edit_button.dart';
+import 'package:notepod/widgets/note_share_button.dart';
 
 class ViewSharedNote extends StatefulWidget {
   final Map fullNoteData;

--- a/lib/widgets/note_edit_scroll_view.dart
+++ b/lib/widgets/note_edit_scroll_view.dart
@@ -112,79 +112,90 @@ class NoteEditScrollView extends StatelessWidget {
       );
     }
 
-    return SingleChildScrollView(
-      child: Column(
-        children: [
-          const SizedBox(
-            height: 10,
-          ),
-          Padding(
-            padding: const EdgeInsets.all(10.0),
-            child: FormBuilder(
-                key: formKey,
-                onChanged: () {
-                  formKey.currentState!.save();
-                },
-                autovalidateMode: AutovalidateMode.disabled,
-                skipDisabled: true,
-                child: Column(
-                  children: [
-                    // New note: show current date
-                    if (prevNoteData == null) ...[
-                      Row(
-                        crossAxisAlignment: CrossAxisAlignment.start,
+    return Column(
+      children: [
+        Expanded(
+          child: SingleChildScrollView(
+            child: Column(
+              children: [
+                const SizedBox(
+                  height: 10,
+                ),
+                Padding(
+                  padding: const EdgeInsets.all(10.0),
+                  child: FormBuilder(
+                      key: formKey,
+                      onChanged: () {
+                        formKey.currentState!.save();
+                      },
+                      autovalidateMode: AutovalidateMode.disabled,
+                      skipDisabled: true,
+                      child: Column(
                         children: [
-                          Text(
-                            'Date: ${currDateStr}',
-                            style: titleStyle,
+                          // New note: show current date
+                          if (prevNoteData == null) ...[
+                            Row(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  'Date: ${currDateStr}',
+                                  style: titleStyle,
+                                ),
+                              ],
+                            ),
+                            const SizedBox(
+                              height: 10,
+                            )
+                          ],
+                          // Edit existing note: populated text field with
+                          // previous note data
+                          FormBuilderTextField(
+                            name: noteTitlePred,
+                            initialValue: (prevNoteData != null)
+                                ? noteContent[noteTitlePred]
+                                : null,
+                            autofocus: true,
+                            decoration: const InputDecoration(
+                              labelText: 'Note Title',
+                              labelStyle: TextStyle(
+                                color: darkBlue,
+                                letterSpacing: 1.5,
+                                fontSize: 13.0,
+                                fontWeight: FontWeight.bold,
+                              ),
+                              //errorText: 'error',
+                            ),
+                            validator: FormBuilderValidators.compose([
+                              FormBuilderValidators.required(),
+                            ]),
                           ),
                         ],
-                      ),
-                      const SizedBox(
-                        height: 10,
-                      )
-                    ],
-                    // Edit existing note: populated text field with
-                    // previous note data
-                    FormBuilderTextField(
-                      name: noteTitlePred,
-                      initialValue: (prevNoteData != null)
-                          ? noteContent[noteTitlePred]
-                          : null,
-                      autofocus: true,
-                      decoration: const InputDecoration(
-                        labelText: 'Note Title',
-                        labelStyle: TextStyle(
-                          color: darkBlue,
-                          letterSpacing: 1.5,
-                          fontSize: 13.0,
-                          fontWeight: FontWeight.bold,
-                        ),
-                        //errorText: 'error',
-                      ),
-                      validator: FormBuilderValidators.compose([
-                        FormBuilderValidators.required(),
-                      ]),
-                    ),
-                  ],
-                )),
+                      )),
+                ),
+                const SizedBox(
+                  height: 10,
+                ),
+                markdownEditor(context, _textController!, _focusNode, data),
+                const SizedBox(
+                  height: 20,
+                ),
+              ],
+            ),
           ),
-          const SizedBox(
-            height: 10,
-          ),
-          markdownEditor(context, _textController!, _focusNode, data),
-          const SizedBox(
-            height: 20,
-          ),
-          Container(
-            padding: const EdgeInsets.only(left: 20, right: 20),
-            child: NoteEditActionBar(),
-          ),
-          const SizedBox(
-            height: 10,
-          ),
-        ],
-      ),
+        ),
+        // Action buttons - always visible
+        Column(
+          children: <Widget>[
+            Container(
+              padding: const EdgeInsets.only(left: 20, right: 20),
+              child: NoteEditActionBar(),
+            ),
+            const SizedBox(
+              height: 10,
+            ),
+          ],
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- Move the action button row to below the singlechildscrollview, making the action buttons always visible

## Associated Issue

- This PR relates to issue #168 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested on ipadOS and macOS - on a long note in view, view_shared and edit, edit shared pages.

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

- [x] Screenshots included in linked issue #
- [x] Changes adhere to the [style and coding guidelines](https://survivor.togaware.com/gnulinux/flutter-style.html)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] The update contains no confidential information
- [x] The update has no duplicated content
- [x] No lint check errors are related to these changes (`make prep` or `flutter analyze lib`)
- [ ] Integration test `dart test` output or screenshot included in issue #
- [x] I tested the PR on these devices:
  - [ ] Android
  - [ ] iOS
  - [x] ipadOS
  - [ ] Linux
  - [x] MacOS
  - [ ] Windows
  - [ ] Web
- [ ] I have identified two reviewers
- [ ] The PR has been approved by two reviewers

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the this branch
- [ ] Resolve any conflicts
- [ ] Add a one line summary into the CHANGELOG.md
- [ ] Push to the git repository and review
- [ ] Merge the PR into dev
