### PR TITLE
Jess/shared with

### DIFF
--- a/lib/common/rest_api/rest_api.dart
+++ b/lib/common/rest_api/rest_api.dart
@@ -21,7 +21,7 @@
 // You should have received a copy of the GNU General Public License along with
 // this program.  If not, see <https://www.gnu.org/licenses/>.
 ///
-/// Authors: Anushka Vidanage, Graham Williams
+/// Authors: Anushka Vidanage, Graham Williams, Jess Moore
 
 library;
 
@@ -37,7 +37,8 @@ import 'package:notepod/utils/rdf.dart';
 
 // Get the list of notes created by the user.
 
-Future<Map> getNoteList(BuildContext context, Widget childPage) async {
+Future<Map<String, dynamic>> getNoteList(
+    BuildContext context, Widget childPage) async {
   final loggedIn = await loginIfRequired(context);
   String webId = await getWebId() as String;
   webId = webId.replaceAll(profCard, '');
@@ -59,7 +60,7 @@ Future<Map> getNoteList(BuildContext context, Widget childPage) async {
       final res = await getResourcesInContainer(notesDirUrl);
       // debugPrint(res.toString());
 
-      Map notesMap = {};
+      Map<String, dynamic> notesMap = {};
       // Loop through the list of files to get the file names
       for (final fileName in res.files) {
         // Read file content
@@ -188,4 +189,36 @@ Future<Map> getSharedNoteContent(
   final noteContentMap = noteInfoMap(noteContent);
 
   return noteContentMap;
+}
+
+/// Get the map of recipient webIDs and their access permission for each files
+/// in a map of notes [notesMap].
+/// Parameters:
+///   [notesMap] is map of filenames to retrieve permissions for.
+///   [fileFlag] set to true if the resource is a file, false if the resource is a directory.
+///   [child] is the child widget to return to
+///   [isFilePath] Set to true if the filename provided is the full path
+Future<dynamic> addRecipientList(
+  Map<String, dynamic> notesMap,
+  BuildContext context,
+  Widget childPage, {
+  bool fileFlag = true,
+  bool isFilePath = true,
+}) async {
+  final List<String> fileList = notesMap.keys.toList();
+
+  // Read recipients for each file
+  for (final fileName in fileList) {
+    // 20250726 jm: While not an external file, as the file
+    // is a full file path, use isExternalRes true, to avoid
+    // readPermission() prepending the filepath.
+    dynamic permList = await readPermission(
+        fileName, fileFlag, context, childPage,
+        isExternalRes: true);
+
+    // Add recipients map to notesMap
+    notesMap[fileName][noteRecipientPred] = permList;
+  }
+
+  return notesMap;
 }

--- a/lib/constants/app.dart
+++ b/lib/constants/app.dart
@@ -38,7 +38,7 @@ const kDefaultPadding = 20.0;
 const double normalLoadingScreenHeight = 200.0;
 const double buttonBorderRadius = 5;
 const double standardSpace = 20.0;
-const double listItemHeight = 88.0;
+const double ownListItemHeight = 108.0;
 const double sharedListItemHeight = 108.0;
 
 double screenWidth(BuildContext context) => MediaQuery.of(context).size.width;

--- a/lib/constants/turtle_structures.dart
+++ b/lib/constants/turtle_structures.dart
@@ -18,7 +18,7 @@
 // You should have received a copy of the GNU General Public License along with
 // this program.  If not, see <https://www.gnu.org/licenses/>.
 ///
-/// Authors: Anushka Vidanage
+/// Authors: Anushka Vidanage, Jess Moore
 library;
 
 // Profile card constant
@@ -40,6 +40,7 @@ String modifiedDateTimePred = 'modifiedDateTime';
 String noteContentPred = 'noteContent';
 String noteTitlePred = 'noteTitle';
 String encNoteContentPred = 'encNoteContent';
+String noteRecipientPred = 'recipient';
 String mePred = ':me';
 String meKey = '#me';
 

--- a/lib/notes/list_notes.dart
+++ b/lib/notes/list_notes.dart
@@ -1,4 +1,4 @@
-/// Individual's PODs app for diabetes care in Yarrabah.
+/// List user's own notes.
 ///
 /// Copyright (C) 2023 Software Innovation Institute, Australian National University
 ///
@@ -204,7 +204,7 @@ class _ListNotesState extends State<ListNotes> {
             child: ListView.builder(
                 padding: const EdgeInsets.all(10),
                 itemCount: _foundNotes.length,
-                itemExtent: listItemHeight,
+                itemExtent: ownListItemHeight,
                 itemBuilder: (context, index) => Card(
                       shape: const RoundedRectangleBorder(
                           borderRadius: BorderRadius.all(Radius.circular(5))),
@@ -218,7 +218,7 @@ class _ListNotesState extends State<ListNotes> {
                         title:
                             Text(_foundNotes[fileNames[index]][noteTitlePred]),
                         subtitle: Text(
-                            'Created on: ${getDateTimeStr(_foundNotes[fileNames[index]][createdDateTimePred])} \nLast modified: ${getDateTimeStr(_foundNotes[fileNames[index]][modifiedDateTimePred])}'),
+                            'Created on: ${getDateTimeStr(_foundNotes[fileNames[index]][createdDateTimePred])} \nLast modified: ${getDateTimeStr(_foundNotes[fileNames[index]][modifiedDateTimePred])}\nShared with: ${getRecipNbrStr(_foundNotes[fileNames[index]][noteRecipientPred].length)}'),
                         trailing: const Icon(Icons.arrow_forward),
                         onTap: () {
                           Navigator.pushAndRemoveUntil(

--- a/lib/notes/list_notes_screen.dart
+++ b/lib/notes/list_notes_screen.dart
@@ -1,4 +1,4 @@
-/// List notes screen
+/// List notes screen - first fetches notes and then gets recipients for the notes
 ///
 /// Copyright (C) 2023 Software Innovation Institute, Australian National University
 ///
@@ -18,7 +18,7 @@
 // You should have received a copy of the GNU General Public License along with
 // this program.  If not, see <https://www.gnu.org/licenses/>.
 ///
-/// Authors: Anushka Vidanage
+/// Authors: Anushka Vidanage, Jess Moore
 library;
 
 import 'package:flutter/material.dart';
@@ -29,6 +29,12 @@ import 'package:notepod/notes/list_notes.dart';
 import 'package:notepod/notes/new_note.dart';
 import 'package:notepod/widgets/loading_screen.dart';
 import 'package:notepod/widgets/msg_card.dart';
+
+/// Process to fetch the user's notes, retrieving the noteData
+/// map where each key is the ttl note file with an embedded map
+/// comprising different properties of the note including content.
+/// The filenames are passed to _loadedNotesScreen() which calls
+/// ListRecipientsScreen() to add the recipients data to each note.
 
 class ListNotesScreen extends StatefulWidget {
   const ListNotesScreen({super.key});
@@ -48,17 +54,16 @@ class _ListNotesScreenState extends State<ListNotesScreen> {
     super.initState();
   }
 
-  // Load Notes
-  Widget _loadedScreen(Map notesMap) {
+  // Load Notes if notes found
+  Widget _loadedNotesScreen(Map<String, dynamic> notesMap) {
     return Container(
-      color: Colors.white,
-      child: ListNotes(
-        notesMap: notesMap,
-      ),
-    );
+        color: Colors.white,
+
+        // Run add recipients fetching screen
+        child: ListRecipientsScreen(notesMap: notesMap));
   }
 
-  // Advise user to create their first note
+  // Advise user to create their first note if no notes found
   Widget _loadNewNote() {
     return SingleChildScrollView(
       child: Column(children: <Widget>[
@@ -89,9 +94,95 @@ class _ListNotesScreenState extends State<ListNotesScreen> {
                         snapshot.data.length == 0
                     // Show _loadNewNote() to go instead to NewNote() when user has no notes
                     ? returnVal = _loadNewNote()
-                    : returnVal = _loadedScreen(
-                        snapshot.data! as Map,
+                    // Else load notes list
+                    : returnVal = _loadedNotesScreen(
+                        snapshot.data! as Map<String, dynamic>,
                       );
+              } else {
+                returnVal = loadingScreen(normalLoadingScreenHeight);
+              }
+              return returnVal;
+            }),
+      ),
+    );
+  }
+}
+
+/// Process to fetch the recipients data for the list of user's notes,
+/// and embed the recipients data with the note data. The ttl filename
+/// of each note is used as the key. The filenames are passed to
+/// _loadedNotesWRecScreen() which calls ListNotes() to display the
+/// list of notes with recipients
+
+class ListRecipientsScreen extends StatefulWidget {
+  final Map<String, dynamic> notesMap;
+  const ListRecipientsScreen({
+    super.key,
+    required this.notesMap,
+  });
+
+  @override
+  State<ListRecipientsScreen> createState() => _ListRecipientsScreenState();
+}
+
+class _ListRecipientsScreenState extends State<ListRecipientsScreen> {
+  final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
+
+  /// Future comprising notesData with recipients added
+
+  static Future? _asyncRecipientsAdd;
+
+  @override
+  void initState() {
+    _asyncRecipientsAdd = addRecipientList(
+      widget.notesMap,
+      context,
+      ListRecipientsScreen(
+        notesMap: widget.notesMap,
+      ),
+    );
+    super.initState();
+  }
+
+  /// Load Notes with recipients data embedded
+  Widget _loadedNotesWRecScreen(Map notesMap) {
+    return Container(
+      color: Colors.white,
+      child: ListNotes(notesMap: notesMap),
+    );
+  }
+
+  /// Load error window
+  Widget _loadNotesWRecError() {
+    return SingleChildScrollView(
+      child: Column(children: <Widget>[
+        buildMsgCard(context, Icons.info, Colors.amber,
+            'Error adding recipients to notes!', 'Yikes',
+            // noNotesMsg,
+            isSmall: true),
+      ]),
+    );
+  }
+
+  // Fetch note recipient data and add to notes map
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      key: _scaffoldKey,
+      body: SafeArea(
+        child: FutureBuilder(
+            future: _asyncRecipientsAdd,
+            builder: (context, snapshot) {
+              Widget returnVal;
+              if (snapshot.connectionState == ConnectionState.done) {
+                debugPrint(
+                    'Finished running _asyncRecipientsAdd to get recipients of each file');
+                // Show error if null returned as null indicates error
+                return snapshot.data == null ||
+                        snapshot.data.toString() == 'null'
+                    ? returnVal = _loadNotesWRecError()
+                    // Else load notes list (which now includes recipients)
+                    : returnVal = _loadedNotesWRecScreen(snapshot.data! as Map);
               } else {
                 returnVal = loadingScreen(normalLoadingScreenHeight);
               }

--- a/lib/utils/misc.dart
+++ b/lib/utils/misc.dart
@@ -75,3 +75,17 @@ String getDateTimeStr(
   final dateFormat = DateFormat(pattern);
   return dateFormat.format(DateTime.parse(dateTimeStr));
 }
+
+/// Get the number of recipients with access to a file, and return as a
+/// String. Where the number of recipients is the number of webIDs with
+/// file access minus one (to exclude the file owner).
+///
+/// Parameters:
+/// [totalNbr] - The total number of webIDs in the permission table
+///              of a resource.
+///
+String getRecipNbrStr(
+  int totalNbr,
+) {
+  return (totalNbr - 1).toString();
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -8,7 +8,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:notepod/main.dart';
+import 'package:notepod/notepod.dart';
 
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- Displays the number of recipients of the file

Solidpod issue suggestion:
Uses new method addRecipientList() which loops through each filename and runs solidpod/src/solid/read_permission.dart read_permission(). This solidpod method takes bool parameter isExternalRes, which is essentially used to describe whether the filename parameter is full filepath URL or not. It would be better for this parameter name to be changed to bool isFilePath. In notepod, the filename of the user's notes is a full file path, so I pass isExternalRes as true, however these are the user's notes and clearly not external resources. I can submit a PR to solidpod with those changes

Notepod follow-on issue:
- UI adjustments are needed to support iPhone (and probably android) as the listItem views on MY NOTEs and SHARED NOTES with multi line subtitles for the metadata are line wrapped on a narrow display. The resulting increased number of lines do not fit in the fixed height listItems, which needs to be conditional on platform to support phone users.

## Associated Issue

- This PR relates to issue #160

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

- [x] Screenshots included in linked issue #
- [x] Changes adhere to the [style and coding guidelines](https://survivor.togaware.com/gnulinux/flutter-style.html)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] The update contains no confidential information
- [x] The update has no duplicated content
- [x] No lint check errors are related to these changes (`make prep` or `flutter analyze lib`)
- [ ] Integration test `dart test` output or screenshot included in issue #
- [x] I tested the PR on these devices:
  - [ ] Android
  - [x] iOS
  - [ ] Linux
  - [ ] MacOS
  - [ ] Windows
  - [ ] Web
- [ ] I have identified two reviewers
- [ ] The PR has been approved by two reviewers

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the this branch
- [ ] Resolve any conflicts
- [ ] Add a one line summary into the CHANGELOG.md
- [ ] Push to the git repository and review
- [ ] Merge the PR into dev
