### PR TITLE
Jess/get resources - supports solidpod PR jess/webid_help

### DIFF
--- a/lib/common/rest_api/rest_api.dart
+++ b/lib/common/rest_api/rest_api.dart
@@ -27,9 +27,10 @@ library;
 
 import 'package:flutter/material.dart';
 
-import 'package:http/http.dart' as http;
 import 'package:solidpod/solidpod.dart';
 import 'package:solidpod/src/solid/api/common_permission.dart';
+import 'package:solidpod/src/solid/api/rest_api.dart';
+import 'package:solidpod/src/solid/constants/common.dart';
 
 import 'package:notepod/constants/turtle_structures.dart';
 import 'package:notepod/utils/encryption.dart';
@@ -53,9 +54,10 @@ Future<Map<String, dynamic>> getNoteList(
 
     // Check if the directory exists.
 
-    bool resExist = await checkResourceStatus(notesDirUrl, fileFlag: false);
+    final ResourceStatus resExist =
+        await checkResourceStatus(notesDirUrl, fileFlag: false);
 
-    if (resExist) {
+    if (resExist == ResourceStatus.exist) {
       //debugPrint('Data: $dataDirUrl');
       final res = await getResourcesInContainer(notesDirUrl);
       // debugPrint(res.toString());
@@ -73,8 +75,12 @@ Future<Map<String, dynamic>> getNoteList(
       }
       // final filteredMap = filterTreatments(treatmentMap, type);
       return notesMap;
-    } else {
+    } else if (resExist == ResourceStatus.notExist) {
       debugPrint('WARN: No data directory for the notes: $notesDirUrl.');
+      return {};
+    } else {
+      debugPrint(
+          'WARN: error occurred when checking the status of notes directory $notesDirUrl.');
       return {};
     }
   } else {
@@ -101,36 +107,6 @@ Map noteInfoMap(String noteContent) {
   };
 
   return noteInfoMap;
-}
-
-// Check if a resource exists in the POD
-Future<bool> checkResourceStatus(
-  String resUrl, {
-  bool fileFlag = true,
-}) async {
-  final (:accessToken, :dPopToken) = await getTokensForResource(resUrl, 'GET');
-  final response = await http.get(
-    Uri.parse(resUrl),
-    headers: <String, String>{
-      'Content-Type': fileFlag ? '*/*' : 'application/octet-stream',
-      'Authorization': 'DPoP $accessToken',
-      'Link': fileFlag
-          ? '<http://www.w3.org/ns/ldp#Resource>; rel="type"'
-          : '<http://www.w3.org/ns/ldp#BasicContainer>; rel="type"',
-      'DPoP': dPopToken,
-    },
-  );
-
-  if (response.statusCode == 200 || response.statusCode == 204) {
-    return true;
-  } else if (response.statusCode == 404) {
-    return false;
-  } else {
-    debugPrint('WARN: Failed to check resource status.\n'
-        'URL: $resUrl\n'
-        'ERR: ${response.body}');
-    return false;
-  }
 }
 
 // Get the Map of shared notes with the current user. If [filesWithGrantAccess]

--- a/lib/common/rest_api/rest_api.dart
+++ b/lib/common/rest_api/rest_api.dart
@@ -35,8 +35,9 @@ import 'package:notepod/constants/turtle_structures.dart';
 import 'package:notepod/utils/encryption.dart';
 import 'package:notepod/utils/rdf.dart';
 
-// Get the list of notes created by the user.
-
+/// Get the map comprising the list of notes and their data to return notesMap.
+/// Parameters:
+///   [childPage] is the child widget to return to
 Future<Map<String, dynamic>> getNoteList(
     BuildContext context, Widget childPage) async {
   final List<String> fileList;

--- a/lib/common/rest_api/rest_api.dart
+++ b/lib/common/rest_api/rest_api.dart
@@ -29,9 +29,8 @@ import 'package:flutter/material.dart';
 
 import 'package:solidpod/solidpod.dart';
 import 'package:solidpod/src/solid/api/common_permission.dart';
-import 'package:solidpod/src/solid/api/rest_api.dart';
 import 'package:solidpod/src/solid/constants/common.dart';
-
+import 'package:solidpod/src/solid/get_resources.dart';
 import 'package:notepod/constants/turtle_structures.dart';
 import 'package:notepod/utils/encryption.dart';
 import 'package:notepod/utils/rdf.dart';
@@ -40,52 +39,30 @@ import 'package:notepod/utils/rdf.dart';
 
 Future<Map<String, dynamic>> getNoteList(
     BuildContext context, Widget childPage) async {
-  final loggedIn = await loginIfRequired(context);
-  String webId = await getWebId() as String;
-  webId = webId.replaceAll(profCard, '');
+  final List<String> fileList;
 
-  if (loggedIn) {
-    final dataDirPath = await getDataDirPath();
-    final dataDirUrl = await getDirUrl(dataDirPath);
+  // Get list of files in user's Pod
+  fileList = await getResources(context, childPage);
 
-    // Why do we need the additional `/`? (20250714 gjw)
+  try {
+    String webId = await getWebId() as String;
+    webId = webId.replaceAll(profCard, '');
 
-    final notesDirUrl = '$dataDirUrl/';
-
-    // Check if the directory exists.
-
-    final ResourceStatus resExist =
-        await checkResourceStatus(notesDirUrl, fileFlag: false);
-
-    if (resExist == ResourceStatus.exist) {
-      //debugPrint('Data: $dataDirUrl');
-      final res = await getResourcesInContainer(notesDirUrl);
-      // debugPrint(res.toString());
-
-      Map<String, dynamic> notesMap = {};
-      // Loop through the list of files to get the file names
-      for (final fileName in res.files) {
-        // Read file content
-        //debugPrint('Read: $fileName');
-        String noteContent =
-            await readPod(fileName.replaceAll(webId, ''), context, childPage);
-        //debugPrint('NoteInfoMap: $fileName');
-        notesMap[fileName] = noteInfoMap(noteContent);
-        //debugPrint('$fileName => ${notesMap[fileName]}');
-      }
-      // final filteredMap = filterTreatments(treatmentMap, type);
-      return notesMap;
-    } else if (resExist == ResourceStatus.notExist) {
-      debugPrint('WARN: No data directory for the notes: $notesDirUrl.');
-      return {};
-    } else {
-      debugPrint(
-          'WARN: error occurred when checking the status of notes directory $notesDirUrl.');
-      return {};
+    Map<String, dynamic> notesMap = {};
+    // Loop through file list to retrieve note data
+    // for each file
+    for (final fileName in fileList) {
+      // Read file content
+      String noteContent =
+          await readPod(fileName.replaceAll(webId, ''), context, childPage);
+      //debugPrint('NoteInfoMap: $fileName');
+      notesMap[fileName] = noteInfoMap(noteContent);
+      //debugPrint('$fileName => ${notesMap[fileName]}');
     }
-  } else {
-    debugPrint('WARN: Not logged in when finding the list of notes.');
-    return {};
+    return notesMap;
+  } on Object catch (e) {
+    debugPrint(e.toString());
+    rethrow;
   }
 }
 

--- a/lib/common/rest_api/rest_api.dart
+++ b/lib/common/rest_api/rest_api.dart
@@ -28,7 +28,6 @@ library;
 import 'package:flutter/material.dart';
 
 import 'package:solidpod/solidpod.dart';
-import 'package:solidpod/src/solid/api/common_permission.dart';
 import 'package:solidpod/src/solid/constants/common.dart';
 import 'package:solidpod/src/solid/get_resources.dart';
 import 'package:notepod/constants/turtle_structures.dart';

--- a/lib/common/rest_api/rest_api.dart
+++ b/lib/common/rest_api/rest_api.dart
@@ -144,35 +144,3 @@ Future<Map> getSharedNoteContent(
 
   return noteContentMap;
 }
-
-/// Get the map of recipient webIDs and their access permission for each files
-/// in a map of notes [notesMap].
-/// Parameters:
-///   [notesMap] is map of filenames to retrieve permissions for.
-///   [fileFlag] set to true if the resource is a file, false if the resource is a directory.
-///   [child] is the child widget to return to
-///   [isFilePath] Set to true if the filename provided is the full path
-Future<dynamic> addRecipientList(
-  Map<String, dynamic> notesMap,
-  BuildContext context,
-  Widget childPage, {
-  bool fileFlag = true,
-  bool isFilePath = true,
-}) async {
-  final List<String> fileList = notesMap.keys.toList();
-
-  // Read recipients for each file
-  for (final fileName in fileList) {
-    // 20250726 jm: While not an external file, as the file
-    // is a full file path, use isExternalRes true, to avoid
-    // readPermission() prepending the filepath.
-    dynamic permList = await readPermission(
-        fileName, fileFlag, context, childPage,
-        isExternalRes: true);
-
-    // Add recipients map to notesMap
-    notesMap[fileName][noteRecipientPred] = permList;
-  }
-
-  return notesMap;
-}

--- a/lib/constants/turtle_structures.dart
+++ b/lib/constants/turtle_structures.dart
@@ -37,7 +37,6 @@ String modifiedDateTimePred = 'modifiedDateTime';
 String noteContentPred = 'noteContent';
 String noteTitlePred = 'noteTitle';
 String encNoteContentPred = 'encNoteContent';
-String noteRecipientPred = 'recipient';
 String mePred = ':me';
 String meKey = '#me';
 

--- a/lib/constants/turtle_structures.dart
+++ b/lib/constants/turtle_structures.dart
@@ -21,19 +21,16 @@
 /// Authors: Anushka Vidanage, Jess Moore
 library;
 
-// Profile card constant
-const String profCard = 'profile/card#me';
+import 'package:solidpod/src/solid/constants/common.dart';
 
 // Directory name constants.
 const mainResDir = 'notepod';
-const dataDir = 'data';
+
 // const myNotesDir = 'mynotes';
 const noteFileNamePrefix = 'note-';
 
 // IRIs (Internationalized Resource Identifiers)
 String notepodTerms = 'https://solidcommunity.au/predicates/terms#';
-String foaf = 'http://xmlns.com/foaf/0.1/';
-String terms = 'http://purl.org/dc/terms/';
 
 String createdDateTimePred = 'createdDateTime';
 String modifiedDateTimePred = 'modifiedDateTime';

--- a/lib/notes/edit_note.dart
+++ b/lib/notes/edit_note.dart
@@ -32,12 +32,25 @@ import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:notepod/constants/turtle_structures.dart';
 import 'package:notepod/widgets/note_edit_scroll_view.dart';
 
-/// The edit note page.
-
+/// A [StatefulWidget] to edit notes owned by the user.
+/// Parameters:
+///   [noteData] - is the data of that note.
+///   [notesMap] - is the file list map with data of all notes
+///                in the user's app data folder (required to support
+///                sharing with suggestion list of recipient WebIds)
 class EditNote extends StatefulWidget {
+  /// Map of the data for the selected note.
   final Map noteData;
 
-  const EditNote({super.key, required this.noteData});
+  /// Map comprising filename list and data for all notes in the user's
+  /// app data folder.
+  final Map notesMap;
+
+  const EditNote({
+    super.key,
+    required this.noteData,
+    required this.notesMap,
+  });
 
   @override
   EditNoteState createState() => EditNoteState();
@@ -97,11 +110,13 @@ class EditNoteState extends State<EditNote>
   @override
   Widget build(BuildContext context) {
     return NoteEditScrollView(
-        formKey: formKey,
-        textController: _textController,
-        focusNode: _focusNode,
-        data: data,
-        prevNoteData: widget.noteData,
-        shared: false);
+      formKey: formKey,
+      textController: _textController,
+      focusNode: _focusNode,
+      data: data,
+      prevNoteData: widget.noteData,
+      shared: false,
+      notesMap: widget.notesMap,
+    );
   }
 }

--- a/lib/notes/list_notes.dart
+++ b/lib/notes/list_notes.dart
@@ -24,6 +24,8 @@ library;
 
 import 'package:flutter/material.dart';
 
+import 'package:solidpod/src/solid/constants/common.dart';
+
 import 'package:notepod/app_screen.dart';
 import 'package:notepod/constants/app.dart';
 import 'package:notepod/constants/turtle_structures.dart';
@@ -218,7 +220,7 @@ class _ListNotesState extends State<ListNotes> {
                         title:
                             Text(_foundNotes[fileNames[index]][noteTitlePred]),
                         subtitle: Text(
-                            'Created on: ${getDateTimeStr(_foundNotes[fileNames[index]][createdDateTimePred])} \nLast modified: ${getDateTimeStr(_foundNotes[fileNames[index]][modifiedDateTimePred])}\nShared with: ${getRecipNbrStr(_foundNotes[fileNames[index]][noteRecipientPred].length)}'),
+                            'Created on: ${getDateTimeStr(_foundNotes[fileNames[index]][createdDateTimePred])} \nLast modified: ${getDateTimeStr(_foundNotes[fileNames[index]][modifiedDateTimePred])}\nShared with: ${getRecipNbrStr(_foundNotes[fileNames[index]][authUserPred].length)}'),
                         trailing: const Icon(Icons.arrow_forward),
                         onTap: () {
                           Navigator.pushAndRemoveUntil(

--- a/lib/notes/list_notes.dart
+++ b/lib/notes/list_notes.dart
@@ -32,6 +32,12 @@ import 'package:notepod/constants/turtle_structures.dart';
 import 'package:notepod/notes/view_note.dart';
 import 'package:notepod/utils/misc.dart';
 
+/// A [StatefulWidget] to list notes owned by the user.
+/// Parameters:
+///   [notesMap] - is the file list map with data of all notes
+///                in the user's app data folder (required to
+///                display sharing information and support
+///                sharing with suggestion list of recipient WebIds).
 class ListNotes extends StatefulWidget {
   final Map notesMap;
 
@@ -230,6 +236,7 @@ class _ListNotesState extends State<ListNotes> {
                                 title: topBarTitle,
                                 childPage: ViewNote(
                                   noteData: _foundNotes[fileNames[index]],
+                                  notesMap: widget.notesMap,
                                 ),
                               ),
                             ),

--- a/lib/notes/list_notes_screen.dart
+++ b/lib/notes/list_notes_screen.dart
@@ -32,12 +32,14 @@ import 'package:notepod/notes/new_note.dart';
 import 'package:notepod/widgets/loading_screen.dart';
 import 'package:notepod/widgets/msg_card.dart';
 
-/// Process to fetch the user's notes, retrieving the noteData
-/// map where each key is the ttl note file with an embedded map
-/// comprising different properties of the note including content.
-/// The filenames are passed to _loadedNotesScreen() which calls
-/// ListRecipientsScreen() to add the recipients data to each note.
-
+/// A [StatefulWidget] that fetches the user's notes in their app data folder,
+/// retrieving the note data map containing data and properties of each note
+/// file name.
+/// Following completion, NewNote() is called if no notes are found.
+/// Alternatively, if notes exist, ListRecipientsScreen() is called to
+/// retrieve the access control list for notes (required to support sharing
+/// of notes and display of sharing information).
+// Parameters: none
 class ListNotesScreen extends StatefulWidget {
   const ListNotesScreen({super.key});
 
@@ -56,16 +58,19 @@ class _ListNotesScreenState extends State<ListNotesScreen> {
     super.initState();
   }
 
-  // Load Notes if notes found
+  /// Load Notes if notes found.
+  /// Parameters:
+  ///   [notesMap] - list of files with data in a user's app data folder.
   Widget _loadedNotesScreen(Map<String, dynamic> notesMap) {
     return Container(
         color: Colors.white,
 
-        // Run add recipients fetching screen
+        // Run to fetch access control list information
         child: ListRecipientsScreen(notesMap: notesMap));
   }
 
-  // Advise user to create their first note if no notes found
+  /// Advise user to create their first note, if no notes found.
+  /// Parameters - none.
   Widget _loadNewNote() {
     return SingleChildScrollView(
       child: Column(children: <Widget>[
@@ -110,14 +115,17 @@ class _ListNotesScreenState extends State<ListNotesScreen> {
   }
 }
 
-/// Process to fetch the recipients data for the list of user's notes,
-/// and embed the recipients data with the note data. The ttl filename
-/// of each note is used as the key. The filenames are passed to
-/// _loadedNotesWRecScreen() which calls ListNotes() to display the
-/// list of notes with recipients
-
+/// A [StatefulWidget] that uses the note filenames in [notesMap]
+/// to retrieve the access control list data for each note filename.
+/// This adds the recipients and permissions of all recipients for
+/// each file record in [notesMap].
+/// After completion, run ListNotes() to display the notes.
+/// Parameters:
+///   [notesMap] is the map comprising a list of notes and data in a
+///              user's Pod.
 class ListRecipientsScreen extends StatefulWidget {
   final Map<String, dynamic> notesMap;
+
   const ListRecipientsScreen({
     super.key,
     required this.notesMap,
@@ -146,7 +154,7 @@ class _ListRecipientsScreenState extends State<ListRecipientsScreen> {
     super.initState();
   }
 
-  /// Load Notes with recipients data embedded
+  /// Load Notes with recipients data embedded.
   Widget _loadedNotesWRecScreen(Map notesMap) {
     return Container(
       color: Colors.white,

--- a/lib/notes/list_notes_screen.dart
+++ b/lib/notes/list_notes_screen.dart
@@ -23,6 +23,8 @@ library;
 
 import 'package:flutter/material.dart';
 
+import 'package:solidpod/src/solid/get_access_lists.dart';
+
 import 'package:notepod/common/rest_api/rest_api.dart';
 import 'package:notepod/constants/app.dart';
 import 'package:notepod/notes/list_notes.dart';
@@ -134,7 +136,7 @@ class _ListRecipientsScreenState extends State<ListRecipientsScreen> {
 
   @override
   void initState() {
-    _asyncRecipientsAdd = addRecipientList(
+    _asyncRecipientsAdd = getAccessLists(
       widget.notesMap,
       context,
       ListRecipientsScreen(

--- a/lib/notes/new_note.dart
+++ b/lib/notes/new_note.dart
@@ -31,12 +31,9 @@ import 'package:flutter_form_builder/flutter_form_builder.dart';
 
 import 'package:notepod/widgets/note_edit_scroll_view.dart';
 
-/// The home page for the app.
-
+/// A [Stateful] widget for creating a new note.
+// Parameters: none
 class NewNote extends StatefulWidget {
-  // final String webId;
-  // final Map authData;
-
   const NewNote({
     super.key,
   });
@@ -98,10 +95,11 @@ class NewNoteState extends State<NewNote> with SingleTickerProviderStateMixin {
   @override
   Widget build(BuildContext context) {
     return NoteEditScrollView(
-        formKey: formKey,
-        textController: _textController,
-        focusNode: _focusNode,
-        data: data,
-        shared: false);
+      formKey: formKey,
+      textController: _textController,
+      focusNode: _focusNode,
+      data: data,
+      shared: false,
+    );
   }
 }

--- a/lib/notes/share_note.dart
+++ b/lib/notes/share_note.dart
@@ -21,7 +21,7 @@
 // You should have received a copy of the GNU General Public License along with
 // this program.  If not, see <https://www.gnu.org/licenses/>.
 ///
-/// Authors: Anushka Vidanage
+/// Authors: Anushka Vidanage, Jess Moore
 
 library;
 
@@ -32,12 +32,24 @@ import 'package:solidpod/solidpod.dart';
 import 'package:notepod/notes/view_note.dart';
 import 'package:notepod/widgets/note_back_button.dart';
 
+/// A [StatefulWidget] for sharing a note owned by the user.
+/// Parameters:
+///   [noteData] - is the data of the selected note to be shared.
+///   [noteFilePath] - is the path of the selected note file.
+///   [notesMap] - is the file list map with data of all notes
+///                in the user's app data folder (required to support
+///                sharing with suggestion list of recipient WebIds)
 class ShareNote extends StatefulWidget {
   final Map noteData;
   final String noteFilePath;
+  final Map notesMap;
 
-  const ShareNote(
-      {super.key, required this.noteData, required this.noteFilePath});
+  const ShareNote({
+    super.key,
+    required this.noteData,
+    required this.noteFilePath,
+    this.notesMap = const {},
+  });
 
   @override
   ShareNoteState createState() => ShareNoteState();
@@ -61,17 +73,20 @@ class ShareNoteState extends State<ShareNote>
               mainAxisSize: MainAxisSize.min,
               children: [
                 const SizedBox(height: 10),
-                NoteBackButton(childPage: ViewNote(noteData: widget.noteData)),
+                NoteBackButton(
+                    childPage: ViewNote(
+                        noteData: widget.noteData, notesMap: widget.notesMap)),
                 const SizedBox(height: 10),
                 SizedBox(
                   height: MediaQuery.of(context).size.height * 0.8,
                   child: GrantPermissionUi(
                     showAppBar: false,
                     fileName: widget.noteFilePath,
+                    dataFilesMap: widget.notesMap as Map<String, dynamic>,
                     child: ShareNote(
-                      noteData: widget.noteData,
-                      noteFilePath: widget.noteFilePath,
-                    ),
+                        noteData: widget.noteData,
+                        noteFilePath: widget.noteFilePath,
+                        notesMap: widget.notesMap),
                   ),
                 ),
               ],

--- a/lib/notes/view_note.dart
+++ b/lib/notes/view_note.dart
@@ -38,12 +38,22 @@ import 'package:notepod/widgets/note_display_metadata.dart';
 import 'package:notepod/widgets/note_edit_button.dart';
 import 'package:notepod/widgets/note_share_button.dart';
 
+/// A [StatefulWidget] to display the text and selected metadata
+/// from the [noteData] of the selected note. Action buttons are
+/// provided to edit and share the note, or go back to the note list.
+/// Parameters:
+///   [noteData] comprises the map of data for the selected note.
+///   [notesMap] comprises the map of data for all note files, owned
+///              by the user in their Pod (required to support
+///              WebId suggestions in note sharing).
 class ViewNote extends StatefulWidget {
   final Map noteData;
+  final Map? notesMap;
 
-  const ViewNote({
+  ViewNote({
     super.key,
     required this.noteData,
+    this.notesMap,
   });
 
   @override
@@ -103,9 +113,9 @@ class _ViewNoteState extends State<ViewNote> {
                   // Share button
                   NoteShareButton(
                       childPage: ShareNote(
-                    noteData: noteData,
-                    noteFilePath: noteFilePath,
-                  )),
+                          noteData: noteData,
+                          noteFilePath: noteFilePath,
+                          notesMap: widget.notesMap as Map<dynamic, dynamic>)),
                   const SizedBox(
                     width: 5,
                   ),
@@ -113,6 +123,7 @@ class _ViewNoteState extends State<ViewNote> {
                   NoteEditButton(
                     childPage: EditNote(
                       noteData: noteData,
+                      notesMap: widget.notesMap as Map<dynamic, dynamic>,
                     ),
                   ),
                   const SizedBox(

--- a/lib/shared_notes/edit_shared_note.dart
+++ b/lib/shared_notes/edit_shared_note.dart
@@ -32,6 +32,13 @@ import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:notepod/constants/turtle_structures.dart';
 import 'package:notepod/widgets/note_edit_scroll_view.dart';
 
+/// A [StatefulWidget] to edit externally owned notes shared to
+/// the user.
+/// Parameters:
+///   [fullNoteData] - is the data of that note, with information
+///                    about the owner, person who shared the note
+///                    to the user, and the user's access rights
+///                    to the note.
 class EditSharedNote extends StatefulWidget {
   final Map fullNoteData;
 
@@ -97,11 +104,13 @@ class EditSharedNoteState extends State<EditSharedNote>
   @override
   Widget build(BuildContext context) {
     return NoteEditScrollView(
-        formKey: formKey,
-        textController: _textController,
-        focusNode: _focusNode,
-        data: data,
-        prevNoteData: widget.fullNoteData,
-        shared: true);
+      formKey: formKey,
+      textController: _textController,
+      focusNode: _focusNode,
+      data: data,
+      prevNoteData: widget.fullNoteData,
+      shared: true,
+      noteInfo: widget.fullNoteData['sharedNoteInfo'],
+    );
   }
 }

--- a/lib/widgets/note_del_button.dart
+++ b/lib/widgets/note_del_button.dart
@@ -26,6 +26,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:solidpod/solidpod.dart';
+import 'package:solidpod/src/solid/constants/common.dart';
 
 import 'package:notepod/app_screen.dart';
 import 'package:notepod/constants/app.dart';

--- a/lib/widgets/note_edit_scroll_view.dart
+++ b/lib/widgets/note_edit_scroll_view.dart
@@ -113,8 +113,11 @@ class NoteEditScrollView extends StatelessWidget {
     }
 
     return Column(
+      mainAxisSize: MainAxisSize.min,
       children: [
-        Expanded(
+        // Expanded(
+        Flexible(
+          fit: FlexFit.loose,
           child: SingleChildScrollView(
             child: Column(
               children: [

--- a/lib/widgets/note_edit_scroll_view.dart
+++ b/lib/widgets/note_edit_scroll_view.dart
@@ -1,4 +1,4 @@
-/// NotePod - A note taking app with notes shared through private PODs.
+/// A widget for creating and editing notes in a SingleChildScrollView()
 ///
 // Time-stamp: <Wednesday 2025-07-18 16:17:37 +1000 Jess Moore>
 ///
@@ -40,6 +40,10 @@ import 'package:notepod/widgets/markdown_editor.dart';
 import 'package:notepod/widgets/note_back_button.dart';
 import 'package:notepod/widgets/note_save_button.dart';
 
+/// A [StatelessWidget] widget setup for calling the
+/// SingleChildScrollView() to edit a note, whether a
+/// new note or a pre-existing note, and whether owned
+/// by the user or shared to the user.
 class NoteEditScrollView extends StatelessWidget {
   const NoteEditScrollView({
     super.key,
@@ -49,6 +53,8 @@ class NoteEditScrollView extends StatelessWidget {
     required this.data,
     this.prevNoteData,
     required this.shared,
+    this.notesMap = const {},
+    this.noteInfo = const {},
   })  : _textController = textController,
         _focusNode = focusNode;
 
@@ -56,14 +62,25 @@ class NoteEditScrollView extends StatelessWidget {
   final TextEditingController? _textController;
   final FocusNode _focusNode;
   final String data;
+
+  /// Existing note data is note already exists
   final Map? prevNoteData;
+
+  /// Sharing metadata about a note
+  final noteInfo;
+
+  /// Boolean describing whether note is shared to pod owner from an
+  /// external source.
   final bool shared;
+
+  /// Map comprising all the note files in a user's app data folder
+  /// on their Pod
+  final Map notesMap;
 
   @override
   Widget build(BuildContext context) {
     String currDateStr = '';
     Map noteContent = {};
-    Map noteInfo = {};
 
     if (prevNoteData == null) {
       // New note: fetch current date for heading
@@ -73,7 +90,7 @@ class NoteEditScrollView extends StatelessWidget {
       // Editing existing note (shared/unshared): extract content
       if (shared) {
         noteContent = prevNoteData!['sharedNoteContent'];
-        noteInfo = prevNoteData!['sharedNoteInfo'];
+        // noteInfo = prevNoteData!['sharedNoteInfo'];
       } else {
         noteContent = prevNoteData as Map<dynamic, dynamic>;
       }
@@ -86,17 +103,21 @@ class NoteEditScrollView extends StatelessWidget {
             // New Note: save button only
             ? [
                 NoteSaveButton(
-                    textController: _textController!,
-                    formKey: formKey,
-                    shared: shared)
+                  textController: _textController!,
+                  formKey: formKey,
+                  shared: shared,
+                  notesMap: notesMap,
+                )
               ]
             : [
                 // Edit Note: save and back buttons
                 NoteSaveButton(
-                    textController: _textController!,
-                    formKey: formKey,
-                    prevNoteData: prevNoteData,
-                    shared: shared),
+                  textController: _textController!,
+                  formKey: formKey,
+                  prevNoteData: prevNoteData,
+                  shared: shared,
+                  notesMap: notesMap,
+                ),
                 const SizedBox(
                   width: 5,
                 ),
@@ -107,7 +128,9 @@ class NoteEditScrollView extends StatelessWidget {
                             ViewSharedNoteScreen(sharedNoteData: noteInfo))
                     : NoteBackButton(
                         childPage: ViewNote(
-                            noteData: prevNoteData as Map<dynamic, dynamic>)),
+                            noteData: prevNoteData as Map<dynamic, dynamic>,
+                            notesMap: notesMap),
+                      ),
               ],
       );
     }
@@ -115,7 +138,6 @@ class NoteEditScrollView extends StatelessWidget {
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
-        // Expanded(
         Flexible(
           fit: FlexFit.loose,
           child: SingleChildScrollView(

--- a/lib/widgets/note_save_button.dart
+++ b/lib/widgets/note_save_button.dart
@@ -27,6 +27,7 @@ import 'package:flutter/material.dart';
 
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:intl/intl.dart';
+import 'package:notepod/notes/list_notes_screen.dart';
 import 'package:solidpod/solidpod.dart';
 
 import 'package:notepod/app_screen.dart';
@@ -47,6 +48,7 @@ class NoteSaveButton extends StatelessWidget {
   final GlobalKey<FormBuilderState> formKey;
   final Map? prevNoteData;
   final bool shared;
+  final Map notesMap;
 
   const NoteSaveButton({
     Key? key,
@@ -54,6 +56,7 @@ class NoteSaveButton extends StatelessWidget {
     required this.formKey,
     this.prevNoteData,
     required this.shared,
+    this.notesMap = const {},
   }) : super(key: key);
 
   @override
@@ -65,7 +68,8 @@ class NoteSaveButton extends StatelessWidget {
       ),
       onPressed: () async {
         // Save note and redirect to view note page
-        await saveNote(context, textController, formKey, prevNoteData, shared);
+        await saveNote(
+            context, textController, formKey, prevNoteData, shared, notesMap);
       },
       style: ElevatedButton.styleFrom(
         foregroundColor: darkBlue,
@@ -89,7 +93,7 @@ class NoteSaveButton extends StatelessWidget {
 
 Future<void> saveNote(BuildContext context,
     TextEditingController _textController, GlobalKey<FormBuilderState> formKey,
-    [Map? prevNoteData, bool shared = false]) async {
+    [Map? prevNoteData, bool shared = false, Map notesMap = const {}]) async {
   if (formKey.currentState?.saveAndValidate() ?? false) {
     // Compares to prevNoteData if previous note data provided
     // Adds sharing metadata if shared==true
@@ -168,12 +172,16 @@ Future<void> saveNote(BuildContext context,
               noteNewData,
               EditNote(
                 noteData: noteNewData,
+                notesMap: notesMap,
               ),
               shared);
 
           // Navigate to return page
           postSaveNav(
-              context, createNoteStatus, ViewNote(noteData: noteNewData));
+            context,
+            createNoteStatus,
+            ViewNote(noteData: noteNewData, notesMap: notesMap),
+          );
         }
       }
     } else {
@@ -196,14 +204,17 @@ Future<void> saveNote(BuildContext context,
 
         // Encrypt note, create TTL and write to file in POD
         createNoteStatus = await saveNoteToPod(
-            context,
-            noteNewData,
-            EditNote(
-              noteData: noteNewData,
-            ));
+          context,
+          noteNewData,
+          ListNotesScreen(),
+        );
 
         // Navigate to return page
-        postSaveNav(context, createNoteStatus, ViewNote(noteData: noteNewData));
+        postSaveNav(
+          context,
+          createNoteStatus,
+          ListNotesScreen(),
+        );
       } else {
         // Nn note content message
         Navigator.pop(context);


### PR DESCRIPTION
# Pull Request Details

**1. REVIEW jess/shared_with PR first, as this builds on that PR**
**2. REVIEW this PR with solidpod branch jess/webid_help**

## What issue does this PR address

- Passes map comprising filelist with ACLs - which is already retrieved by ListNotesScreen() - to the GrantPermissionUI(). This avoid an additional future call. This passed data is used to support a drop down suggestion list of current recipients of any file in a user's pod, when a user is sharing a file.
- Documentation added to classes of widgets changed in this PR.

## Associated Issue

- This PR relates to issue #295 - see images in issue.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] New note - save, back
- [x] List note - select note, edit, share, delete and back
- [x] List shared note - select note, edit, share, delete and back

Found 1 issue, and confirmed that it is pre-existing as occurs on dev too. Adding it as a separate issue. It occurs when sharing an external note. On clicking Individual to share to an individual, the suggestion list naturally shows webid's of people with access to the note, excluding the user. If Person B who is the recipient of the external note, chooses to try to grant permissions of Person A, where person A is the creator/owner of the note, the app hangs on click of 'Grant Permission'.

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

- [x] Screenshots included in linked issue #
- [x] Changes adhere to the [style and coding guidelines](https://survivor.togaware.com/gnulinux/flutter-style.html)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] The update contains no confidential information
- [x] The update has no duplicated content
- [x] No lint check errors are related to these changes (`make prep` or `flutter analyze lib`)
- [ ] Integration test `dart test` output or screenshot included in issue #
- [x] I tested the PR on these devices:
  - [ ] Android
  - [x] iOS
  - [ ] Linux
  - [ ] MacOS
  - [ ] Windows
  - [x] Web
- [ ] I have identified two reviewers
- [ ] The PR has been approved by two reviewers

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the this branch
- [ ] Resolve any conflicts
- [ ] Add a one line summary into the CHANGELOG.md
- [ ] Push to the git repository and review
- [ ] Merge the PR into dev
