### PR TITLE
pop saving note dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ au](https://solidcommunity.au/docs/notepod)
 
 ## 0.3 Review and Consolidate
 
-+ Fix ocassional bug where saving note indicator was not closing [0.2.X 20250926 jesscmoore]
++ Fix saving note not closing bug [0.2.X 20250926 jesscmoore]
 + Show title if permission in Shared Notes list [0.2.33 20250922 jesscmoore]
 + Quick share button if permission in Shared Notes [0.2.32 20250921 jesscmoore]
 + Remove import of lib/src from solidpod [0.2.31 20250917 gjw]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ au](https://solidcommunity.au/docs/notepod)
 
 ## 0.3 Review and Consolidate
 
++ Fix ocassional bug where saving note indicator was not closing [0.2.X 20250926 jesscmoore]
 + Show title if permission in Shared Notes list [0.2.33 20250922 jesscmoore]
 + Quick share button if permission in Shared Notes [0.2.32 20250921 jesscmoore]
 + Remove import of lib/src from solidpod [0.2.31 20250917 gjw]

--- a/lib/widgets/note_del_button.dart
+++ b/lib/widgets/note_del_button.dart
@@ -86,6 +86,9 @@ class NoteDelButton extends StatelessWidget {
                     }
 
                     if (context.mounted) {
+                      Navigator.of(context, rootNavigator: true)
+                          .pop(); // Dismiss the deleting note dialog
+
                       Navigator.pushAndRemoveUntil(
                         context,
                         MaterialPageRoute(
@@ -103,8 +106,8 @@ class NoteDelButton extends StatelessWidget {
                 ),
                 TextButton(
                   onPressed: () {
-                    // Close the dialog
-                    Navigator.of(context).pop();
+                    Navigator.of(context, rootNavigator: true)
+                        .pop(); // Dismiss the deleting note dialog
                   },
                   child: const Text('No'),
                 ),

--- a/lib/widgets/note_save_button.dart
+++ b/lib/widgets/note_save_button.dart
@@ -371,6 +371,9 @@ Future<void> saveNoteToPod(
     if (createNoteStatus == SolidFunctionCallStatus.success) {
       if (!context.mounted) return;
 
+      Navigator.of(context, rootNavigator: true)
+          .pop(); // Dismiss the saving note dialog
+
       Navigator.pushAndRemoveUntil(
         context,
         MaterialPageRoute(
@@ -383,12 +386,24 @@ Future<void> saveNoteToPod(
             false, // This predicate ensures all previous routes are removed
       );
     } else {
+      // Show SolidFunctionCallStatus after writePod() if not success
+      debugPrint(
+        'SolidFunctionCallStatus: ${createNoteStatus.toString()}',
+      );
+
       if (!context.mounted) return;
+
+      Navigator.of(context, rootNavigator: true)
+          .pop(); // Dismiss the saving note dialog
 
       showErrDialog(
         context,
         ErrMsg.saveFailed,
       );
+    }
+
+    if (!context.mounted) {
+      throw Exception('Context not found');
     }
   } on Exception catch (e) {
     debugPrint(


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- Navigator.pushAndRemoveUntil() does not reliably close a showDialog(). Must be preceded by Navigator.of(context, rootNavigator: true).pop();
- This PR relates to issue #158

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

On iOS:
- Logout of user A
- Login to user B
- Create new note and click SAVE
- After writePod() returns success, the saving note showDialog() should close and nav to note list.

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

- [x] Screenshots included in linked issue #
- [x] Changes adhere to the [style and coding guidelines](https://survivor.togaware.com/gnulinux/flutter-style.html)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] The update contains no confidential information
- [x] The update has no duplicated content
- [x] No lint check errors are related to these changes (`make prep` or `flutter analyze lib`)
- [ ] I tested the PR on these devices:
  - [ ] Android
  - [x] iOS
  - [ ] Linux
  - [ ] MacOS
  - [ ] Windows
  - [ ] Web
- [ ] I have identified two reviewers
- [ ] The PR has been approved by two reviewers

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the this branch
- [ ] Resolve any conflicts
- [ ] Add a one line summary into the CHANGELOG.md
- [ ] Push to the git repository and review
- [ ] Merge the PR into dev
