### PR TITLE
Removed unused SingleTickerProviderStateMixin on stateful widgets

### DIFF
--- a/lib/home.dart
+++ b/lib/home.dart
@@ -46,8 +46,7 @@ class AppHomePage extends StatefulWidget {
   AppHomePageState createState() => AppHomePageState();
 }
 
-class AppHomePageState extends State<AppHomePage>
-    with SingleTickerProviderStateMixin {
+class AppHomePageState extends State<AppHomePage> {
   String? _webId;
 
   String _appVersion = '';

--- a/lib/notes/edit_note.dart
+++ b/lib/notes/edit_note.dart
@@ -57,8 +57,7 @@ class EditNote extends StatefulWidget {
   EditNoteState createState() => EditNoteState();
 }
 
-class EditNoteState extends State<EditNote>
-    with SingleTickerProviderStateMixin {
+class EditNoteState extends State<EditNote> {
   final formKey = GlobalKey<FormBuilderState>();
 
   TextEditingController? _textController;

--- a/lib/notes/new_note.dart
+++ b/lib/notes/new_note.dart
@@ -43,7 +43,7 @@ class NewNote extends StatefulWidget {
   NewNoteState createState() => NewNoteState();
 }
 
-class NewNoteState extends State<NewNote> with SingleTickerProviderStateMixin {
+class NewNoteState extends State<NewNote> {
   final formKey = GlobalKey<FormBuilderState>();
 
   TextEditingController? _textController;

--- a/lib/notes/share_note.dart
+++ b/lib/notes/share_note.dart
@@ -56,8 +56,7 @@ class ShareNote extends StatefulWidget {
   ShareNoteState createState() => ShareNoteState();
 }
 
-class ShareNoteState extends State<ShareNote>
-    with SingleTickerProviderStateMixin {
+class ShareNoteState extends State<ShareNote> {
   /// Scroll controller for single child scroll view
   late final ScrollController _scrollController;
 

--- a/lib/shared_notes/edit_shared_note.dart
+++ b/lib/shared_notes/edit_shared_note.dart
@@ -49,8 +49,7 @@ class EditSharedNote extends StatefulWidget {
   EditSharedNoteState createState() => EditSharedNoteState();
 }
 
-class EditSharedNoteState extends State<EditSharedNote>
-    with SingleTickerProviderStateMixin {
+class EditSharedNoteState extends State<EditSharedNote> {
   final formKey = GlobalKey<FormBuilderState>();
 
   TextEditingController? _textController;

--- a/lib/shared_notes/share_external_note.dart
+++ b/lib/shared_notes/share_external_note.dart
@@ -48,8 +48,7 @@ class ShareExternalNote extends StatefulWidget {
   ShareExternalNoteState createState() => ShareExternalNoteState();
 }
 
-class ShareExternalNoteState extends State<ShareExternalNote>
-    with SingleTickerProviderStateMixin {
+class ShareExternalNoteState extends State<ShareExternalNote> {
   /// Scroll controller for single child scroll view
   late final ScrollController _scrollController;
 

--- a/lib/widgets/loading_animation.dart
+++ b/lib/widgets/loading_animation.dart
@@ -43,11 +43,6 @@ showAnimationDialog(
       return Padding(
         padding: const EdgeInsets.all(50),
         child: Center(
-          // child: SpinKitThreeBounce(
-          //   color: anuCopper,
-          //   size: 100.0,
-          //   //controller: AnimationController(vsync: this, duration: const Duration(milliseconds: 1200)),
-          // ),
           child: SizedBox(
             width: 150,
             height: 250,

--- a/lib/widgets/loading_animation.dart
+++ b/lib/widgets/loading_animation.dart
@@ -27,7 +27,7 @@ library;
 
 import 'package:flutter/material.dart';
 
-import 'package:loading_indicator/loading_indicator.dart';
+import 'package:new_loading_indicator/new_loading_indicator.dart';
 
 import 'package:notepod/constants/colours.dart';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,8 @@ dependencies:
   flutter_form_builder: ^10.0.1
   form_builder_validators: ^11.1.2
   intl: any
-  loading_indicator: ^3.1.1
+  # loading_indicator: ^3.1.1
+  new_loading_indicator: 1.0.2
   markdown_toolbar: ^0.5.0
   markdown_widget: ^2.3.2+8
   package_info_plus: ^8.3.0


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- Many of the stateful widgets included  'with SingleTickerProviderStateMixin' which is not necessary as we loading_indicator does not use an AnimationController(). Removed this.
- Note this obsolete code is also in several solidpod stateful widgets
- replaced loading_indicator packages with new_loading_indicator which has updated dependencies https://pub.dev/packages/new_loading_indicator

- associated issue #219 

## How Has This Been Tested?

On iOS:
- created note, accessed and edited my notes, accessed shared note.

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

- [x] No lint check errors are related to these changes (`make prep` or `flutter analyze lib`)
- [ ] I tested the PR on these devices:
  - [ ] Android
  - [x] iOS
  - [ ] Linux
  - [ ] MacOS
  - [ ] Windows
  - [ ] Web
- [ ] I have identified two reviewers
- [ ] The PR has been approved by two reviewers

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the this branch
- [ ] Resolve any conflicts
- [ ] Add a one line summary into the CHANGELOG.md
- [ ] Push to the git repository and review
- [ ] Merge the PR into dev
