### PR TITLE
Jess/fix private state types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ a Pull Request. Thanks.
 
 ## 0.3 Review and Consolidate
 
++ Fixed rendering error on titles of external notes [0.2.46 20251019 jesscmoore]
++ Fixed initialisaiton error on unreadable note [0.2.46 20251019 jesscmoore]
 + Fixed rendering error on unreadable note [0.2.45 20251016 jesscmoore]
 + Update snap/android config for secure storage [0.2.44 20251010 gjw]
 + Fixed save to secure storage bug on macos [0.2.43 20251010 jesscmoore]

--- a/lib/notes/list_notes.dart
+++ b/lib/notes/list_notes.dart
@@ -49,8 +49,7 @@ class ListNotes extends StatefulWidget {
   });
 
   @override
-  // ignore: library_private_types_in_public_api
-  _ListNotesState createState() => _ListNotesState();
+  State<ListNotes> createState() => _ListNotesState();
 }
 
 class _ListNotesState extends State<ListNotes> {

--- a/lib/notes/view_note.dart
+++ b/lib/notes/view_note.dart
@@ -52,8 +52,7 @@ class ViewNote extends StatefulWidget {
   });
 
   @override
-  // ignore: library_private_types_in_public_api
-  _ViewNoteState createState() => _ViewNoteState();
+  State<ViewNote> createState() => _ViewNoteState();
 }
 
 class _ViewNoteState extends State<ViewNote> {

--- a/lib/shared_notes/list_external_notes.dart
+++ b/lib/shared_notes/list_external_notes.dart
@@ -410,7 +410,8 @@ class TitleExternalNote extends StatelessWidget {
             note: _note,
           ),
         ] else ...[
-          const Text('Title access requires read permission'),
+          // Display nothing as no read permission
+          const Text(''),
         ],
       ],
     );

--- a/lib/shared_notes/list_external_notes.dart
+++ b/lib/shared_notes/list_external_notes.dart
@@ -49,8 +49,7 @@ class ListExternalNotes extends StatefulWidget {
   });
 
   @override
-  // ignore: library_private_types_in_public_api
-  _ListExternalNotesState createState() => _ListExternalNotesState();
+  State<ListExternalNotes> createState() => _ListExternalNotesState();
 }
 
 class _ListExternalNotesState extends State<ListExternalNotes> {

--- a/lib/shared_notes/non_readable_note.dart
+++ b/lib/shared_notes/non_readable_note.dart
@@ -52,8 +52,7 @@ class NonReadableNote extends StatefulWidget {
   });
 
   @override
-  // ignore: library_private_types_in_public_api
-  _NonReadableNoteState createState() => _NonReadableNoteState();
+  State<NonReadableNote> createState() => _NonReadableNoteState();
 }
 
 class _NonReadableNoteState extends State<NonReadableNote> {

--- a/lib/shared_notes/non_readable_note.dart
+++ b/lib/shared_notes/non_readable_note.dart
@@ -69,6 +69,7 @@ class _NonReadableNoteState extends State<NonReadableNote> {
   void initState() {
     super.initState();
     _scrollController = ScrollController();
+    _note = widget.note;
   }
 
   @override

--- a/lib/shared_notes/view_shared_note.dart
+++ b/lib/shared_notes/view_shared_note.dart
@@ -51,8 +51,7 @@ class ViewSharedNote extends StatefulWidget {
   });
 
   @override
-  // ignore: library_private_types_in_public_api
-  _ViewSharedNoteState createState() => _ViewSharedNoteState();
+  State<ViewSharedNote> createState() => _ViewSharedNoteState();
 }
 
 class _ViewSharedNoteState extends State<ViewSharedNote> {


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- Fixes ignored warning of private types in public apis.
- Also fixes initialisation error in unreadable note viewing, and title overflow error in external note lists.
-  Updated changelog, please bump minor version
- This PR relates to issue #282

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Yes, viewing external and own notes and unreadable notes on iOS.

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

- [ ] Screenshots included in linked issue #
- [x] Changes adhere to the [style and coding guidelines](https://survivor.togaware.com/gnulinux/flutter-style.html)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] The update contains no confidential information
- [x] The update has no duplicated content
- [x] No lint check errors are related to these changes (`make prep` or `flutter analyze lib`)
- [ ] Integration test `dart test` output or screenshot included in issue #
- [x] I tested the PR on these devices:
  - [ ] Android
  - [x] iOS
  - [ ] Linux
  - [ ] MacOS
  - [ ] Windows
  - [ ] Web
- [ ] I have identified reviewers
- [ ] The PR has been approved by reviewers

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the this branch
- [ ] Resolve any conflicts
- [ ] Add a one line summary into the CHANGELOG.md
- [ ] Push to the git repository and review
- [ ] Merge the PR into dev
