### PR TITLE
Jess/show filenames

### DIFF
--- a/lib/constants/ui.dart
+++ b/lib/constants/ui.dart
@@ -65,13 +65,15 @@ class NoteItemSize {
   /// modified date time are line wrapped to
   /// two lines.)
 
-  static const double compressedOwnItemHeight = 190;
+  static const double compressedOwnItemHeight =
+      260; // (4 row subtitle) 190; (3 row subtitle)
 
   /// Approximate height of uncompressed item
   /// in user's own notes list
   /// when list item text is not line wrapped.
 
-  static const double uncompressedOwnItemHeight = 108;
+  static const double uncompressedOwnItemHeight =
+      138; // (4 row subtitle) 108; (3 row subtitle)
 
   /// Approximate height of compressed item
   /// in user's external notes list
@@ -81,13 +83,13 @@ class NoteItemSize {
   /// modified date time are line wrapped to
   /// two lines.)
 
-  static const double compressedExtItemHeight = 260;
+  static const double compressedExtItemHeight = 260; // (4 row subtitle)
 
   /// Approximate height of uncompressed item
   /// in user's external notes list
   /// when list item text is not line wrapped.
 
-  static const double uncompressedExtItemHeight = 138;
+  static const double uncompressedExtItemHeight = 138; // (4 row subtitle)
 
   /// Calculate card aspect ratio to use for
   /// gridview builder cards using the box

--- a/lib/notes/list_notes.dart
+++ b/lib/notes/list_notes.dart
@@ -354,6 +354,7 @@ class _ListNotesState extends State<ListNotes> {
                               _foundNotes[index].content.noteTitle,
                             ),
                             subtitle: Text(
+                              'Filename: ${_foundNotes[index].noteFileName} \n'
                               'Created on: ${getDateTimeStr(_foundNotes[index].content.createdDateTime)} \n'
                               'Last modified: ${getDateTimeStr(_foundNotes[index].content.modifiedDateTime)}\n'
                               'Shared with: ${getRecipNbrStr(_foundNotes[index].content.authUsers.length)}',

--- a/lib/notes/view_note.dart
+++ b/lib/notes/view_note.dart
@@ -111,7 +111,9 @@ class _ViewNoteState extends State<ViewNote> {
                   DisplayNoteMetadata(
                     createdDateTime: _note.content.createdDateTime,
                     modifiedDateTime: _note.content.modifiedDateTime,
+                    noteFileName: _note.noteFileName,
                     showDates: true,
+                    showFileName: true,
                   ),
                   // Display markdown note content
                   noteDisplayMarkdown(

--- a/lib/shared_notes/non_readable_note.dart
+++ b/lib/shared_notes/non_readable_note.dart
@@ -94,6 +94,7 @@ class _NonReadableNoteState extends State<NonReadableNote> {
               permissionList: _note.permissionList,
               noteFileName: _note.noteFileName,
               noteUrl: _note.noteUrl,
+              showFileName: true,
               showSharing: true,
               showPathInfo: true,
             ),

--- a/lib/shared_notes/view_shared_note.dart
+++ b/lib/shared_notes/view_shared_note.dart
@@ -120,7 +120,9 @@ class _ViewSharedNoteState extends State<ViewSharedNote> {
                     noteFileName: _note.noteFileName,
                     noteUrl: _note.noteUrl,
                     showDates: true,
+                    showFileName: true,
                     showSharing: true,
+                    showPathInfo: true,
                   ),
                   // Display markdown note content
                   noteDisplayMarkdown(_note.content!.noteContent),

--- a/lib/widgets/note_display_metadata.dart
+++ b/lib/widgets/note_display_metadata.dart
@@ -28,6 +28,7 @@ import 'package:flutter/material.dart';
 
 import 'package:notepod/widgets/show_access_metadata.dart';
 import 'package:notepod/widgets/show_date_metadata.dart';
+import 'package:notepod/widgets/show_filename_metadata.dart';
 import 'package:notepod/widgets/show_path_metadata.dart';
 
 /// Display the metadata of an externally owned note.
@@ -45,6 +46,14 @@ import 'package:notepod/widgets/show_path_metadata.dart';
 /// - [permissionList] - list of permissions granted to the user.
 /// - [noteFileName] - note file name.
 /// - [noteUrl] - url of note.
+/// - [showDates] - flag describing whether to show data metadata of
+/// note.
+/// - [showFileName] - flag describing whether to show filename of
+/// note.
+/// - [showSharing] - flag describing whether to show sharing
+/// metadata of note.
+/// - [showPathInfo] - flag describing whether to show url path of
+/// note.
 
 class DisplayNoteMetadata extends StatelessWidget {
   final String createdDateTime;
@@ -56,6 +65,7 @@ class DisplayNoteMetadata extends StatelessWidget {
   final String noteUrl;
 
   final bool showDates;
+  final bool showFileName;
   final bool showSharing;
   final bool showPathInfo;
 
@@ -69,6 +79,7 @@ class DisplayNoteMetadata extends StatelessWidget {
     this.noteFileName = '',
     this.noteUrl = '',
     this.showDates = false,
+    this.showFileName = false,
     this.showSharing = false,
     this.showPathInfo = false,
   });
@@ -81,6 +92,9 @@ class DisplayNoteMetadata extends StatelessWidget {
         mainAxisAlignment: MainAxisAlignment.center,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
+          // ShowFileName
+          if (showFileName && noteFileName.isNotEmpty)
+            ShowFilenameMetadata(filename: noteFileName),
           // ShowDates (created and modified)
           if (showDates &&
               createdDateTime.isNotEmpty &&
@@ -100,8 +114,7 @@ class DisplayNoteMetadata extends StatelessWidget {
               permissionList: permissionList,
             ),
           // Show path info (filename and path)
-          if (showPathInfo && noteFileName != '' && noteUrl != '')
-            ShowPathMetadata(filename: noteFileName, fileUrl: noteUrl),
+          if (showPathInfo && noteUrl != '') ShowPathMetadata(fileUrl: noteUrl),
           const SizedBox(height: 10),
         ],
       ),

--- a/lib/widgets/show_filename_metadata.dart
+++ b/lib/widgets/show_filename_metadata.dart
@@ -1,6 +1,6 @@
-/// Widget for display of path metadata for a note
+/// Widget for display of filename metadata for a note
 ///
-// Time-stamp: <Friday 2025-10-14 14:59:05 +1000 Graham Williams>
+// Time-stamp: <Friday 2025-10-30 16:36:05 +1100 Graham Williams>
 ///
 /// Copyright (C) 2025, Software Innovation Institute, ANU
 ///
@@ -28,17 +28,17 @@ import 'package:flutter/material.dart';
 
 import 'package:notepod/constants/app.dart';
 
-/// Display path metadata of a note ie. the filename and path.
+/// Display filename metadata of a note ie. the filename.
 ///
 /// Arguments:
-/// - [fileUrl] - Url of the note.
+/// - [filename] - Filename of the note.
 
-class ShowPathMetadata extends StatelessWidget {
-  final String fileUrl;
+class ShowFilenameMetadata extends StatelessWidget {
+  final String filename;
 
-  const ShowPathMetadata({
+  const ShowFilenameMetadata({
     super.key,
-    required this.fileUrl,
+    required this.filename,
   });
 
   @override
@@ -54,7 +54,7 @@ class ShowPathMetadata extends StatelessWidget {
                 child: Container(
                   padding: metadataPadding,
                   child: Text(
-                    'Note path: $fileUrl',
+                    'Note file name: $filename',
                     style: metadataTextStyle,
                   ),
                 ),

--- a/lib/widgets/show_path_metadata.dart
+++ b/lib/widgets/show_path_metadata.dart
@@ -54,7 +54,7 @@ class ShowPathMetadata extends StatelessWidget {
                 child: Container(
                   padding: metadataPadding,
                   child: Text(
-                    'Note path: $fileUrl',
+                    'Note url: $fileUrl',
                     style: metadataTextStyle,
                   ),
                 ),


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- Include note filename in places where it was missing: own note list, view of own note, view of external note.

## Associated Issue

- This PR relates to issue #296 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

on ios simulator:
- open my notes list, view a note
- open external notes list, view a readable note and a unreadable note.

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

- [x] Screenshots included in linked issue #
- [x] Changes adhere to the [style and coding guidelines](https://survivor.togaware.com/gnulinux/flutter-style.html)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] The update contains no confidential information
- [x] The update has no duplicated content
- [ ] No lint check errors are related to these changes (`make prep` or `flutter analyze lib`)
- [ ] Integration test `dart test` output or screenshot included in issue #
- [ ] I tested the PR on these devices:
  - [ ] Android
  - [x] iOS
  - [ ] Linux
  - [ ] MacOS
  - [ ] Windows
  - [ ] Web
- [ ] I have identified reviewers
- [ ] The PR has been approved by reviewers

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the this branch
- [ ] Resolve any conflicts
- [ ] Add a one line summary into the CHANGELOG.md
- [ ] Push to the git repository and review
- [ ] Merge the PR into dev
