### PR TITLE
update writePod call as requiredfor solidpod 0.9.0 updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ a Pull Request. Thanks.
 
 ## 0.4
 
++ Fix writePod calls as required for solidpod 0.9.0 [0.3.4 20260112 jesscmoore]
 + Update to solidpod 0.9.0 and solidui 0.0.22 [0.3.4 20260109 jesscmoore]
 + Added deletion of multiple notes [0.3.3 20260108 jesscmoore]
 + Fix const IconData issue for macOS #152 [0.3.2 20260108 tonypioneer]

--- a/lib/common/rest_api/file_helper.dart
+++ b/lib/common/rest_api/file_helper.dart
@@ -360,6 +360,7 @@ class NoteFileHelper with PodOperationsMixin {
                 // Use existing filename
                 noteFileName: prevOwnNote.noteFileName,
                 data: updatedContent,
+                overwrite: true,
                 childPage: ViewNote(
                   note: updatedOwnNote,
                   scaffoldController: scaffoldController,
@@ -440,7 +441,8 @@ class NoteFileHelper with PodOperationsMixin {
   /// that are externally owned.
   /// - [noteOwner] - Optional note owner webId. Required for saving notes
   /// that are externally owned.
-  /// - [isExternal] - Optional boolean defining whether updating an existing external note. (Default: false).
+  /// - [overwrite] - Optional boolean defining whether updating an existing owner's note.
+  /// - [isExternal] - Optional boolean defining whether writing an external note.
 
   Future<void> saveNoteToPod({
     required BuildContext context,
@@ -450,6 +452,7 @@ class NoteFileHelper with PodOperationsMixin {
     String noteFileName = '',
     String noteUrl = '',
     String noteOwner = '',
+    bool overwrite = false,
     bool isExternal = false,
   }) async {
     try {
@@ -485,6 +488,7 @@ class NoteFileHelper with PodOperationsMixin {
         await writePod(
           noteFileName,
           noteTTLStr,
+          overwrite: overwrite,
         );
       }
 


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- Updates writePod() call as required for writePod in solidpod v0.9.0

## Associated Issue

- This PR relates to issue #338 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

On ios, saved an existing note.

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

- [ ] Screenshots included in linked issue #
- [ ] Changes adhere to the [style and coding guidelines](https://survivor.togaware.com/gnulinux/flutter-style.html)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] The update contains no confidential information
- [x] The update has no duplicated content
- [x] No lint check errors are related to these changes (`make prep` or `flutter analyze lib`)
- [ ] Integration test `dart test` output or screenshot included in issue #
- [x] I tested the PR on these devices:
  - [ ] Android
  - [x] iOS
  - [ ] Linux
  - [ ] MacOS
  - [ ] Windows
  - [ ] Web
- [x] I have identified reviewers
- [ ] The PR has been approved by reviewers

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the this branch
- [ ] Resolve any conflicts
- [ ] Add a one line summary into the CHANGELOG.md
- [ ] Push to the git repository and review
- [ ] Merge the PR into dev
