### PR TITLE
remove specification of the granter in the call to GrantPermissionUi()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ a Pull Request. Thanks.
 
 ## 0.4
 
++ Corrects granterWebId in sharing process [0.3.8 20260205 jesscmoore]
 + Remove redundant logout button [0.3.7 20260123 tonypioneer]
 + Bug fix: CONTINUE when not logged in [0.3.6 20260123 tonypioneer]
 + Dependency cleanup and update [0.3.5 20260119 gjw]

--- a/lib/shared_notes/share_external_note.dart
+++ b/lib/shared_notes/share_external_note.dart
@@ -97,9 +97,6 @@ class ShareExternalNoteState extends State<ShareExternalNote> {
                   const SizedBox(height: 10),
                   NoteBackButton(
                     childPage: widget.backPage,
-                    // childPage: ListExternalNotesScreen(
-                    //   scaffoldController: _scaffoldController,
-                    // ),
                     scaffoldController: _scaffoldController,
                   ),
                   const SizedBox(height: 10),
@@ -110,7 +107,6 @@ class ShareExternalNoteState extends State<ShareExternalNote> {
                       resourceName: _note.noteUrl,
                       isExternalRes: true,
                       ownerWebId: _note.noteOwner,
-                      granterWebId: _note.permissionGranter,
                       child: ShareExternalNote(
                         note: _note,
                         backPage: widget.backPage,


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- Fixes call to GrantPermissionUi() so the correct granter webid is written to permissions

## Associated Issue

- This PR relates to issue #356 jess/351_corr_granter and solidpod jess/581_corr_granter.
- Requires solidpod jess/581_corr_granter 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

- [x] Screenshots included in linked issue #
- [x] Changes adhere to the [style and coding guidelines](https://survivor.togaware.com/gnulinux/flutter-style.html)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] The update contains no confidential information
- [x] The update has no duplicated content
- [x] No lint check errors are related to these changes (`make prep` or `flutter analyze lib`)
- [ ] Integration test `dart test` output or screenshot included in issue #
- [x] I tested the PR on these devices:
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] MacOS
  - [ ] Windows
  - [ ] Web
- [ ] I have identified reviewers
- [ ] The PR has been approved by reviewers

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the this branch
- [ ] Resolve any conflicts
- [ ] Add a one line summary into the CHANGELOG.md
- [ ] Push to the git repository and review
- [ ] Merge the PR into dev
