### PR TITLE
Jess/390 key finding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ a Pull Request. Thanks.
 
 ## 0.4
 
++ Optimise multi file load from different owners [0.3.14 20260415 jesscmoore]
++ Fix appbar preferences overflow [0.3.13 20260406 tonypioneer]
 + IOS build settings for iOS 26.4 UIScene migration [0.3.12 20260406 jesscmoore]
 + Fix closing of save dialog [0.3.11 20260320 jesscmoore]
 + Make delete inactive if external selected and fix icon [0.3.10 20260319 jesscmoore]

--- a/lib/common/rest_api/rest_api.dart
+++ b/lib/common/rest_api/rest_api.dart
@@ -62,25 +62,48 @@ Future<NotesCallResult> getOwnNoteList() async {
     // Get file list in owner's Pod
     fileList = await NoteFileHelper().scanFileListDirectory();
 
+    if (fileList.isEmpty) {
+      // Return empty result if no files in Pod
+      debugPrint('No files found!');
+    } else {
+      debugPrint('${fileList.length} user owned files in Pod');
+    }
+
     // Create a list of future functions for reading pod and
     // getting fileUrl
+    // Fetch file URLs in parallel (safe — pure URL construction).
     List<Future<String>> futuresFileUrl = [];
-    List<Future<String>> futuresNoteContentResult = [];
     for (final fileName in fileList) {
       futuresFileUrl.add(
         filenameToResourceUrl(
           fileName: fileName,
         ),
       );
-      futuresNoteContentResult.add(
-        readPod(fileName),
-      );
     }
 
     // Read note file content and fetch file Urls
     List<String> fileUrls = await Future.wait(futuresFileUrl);
-    List<String> noteContentResults =
-        await Future.wait(futuresNoteContentResult);
+
+    // Run readPod() to fetch ttl strings of decrypted book records
+    // The first readPod() call populates IndividualKeyManager._indKeyMap and
+    // KeyManager._masterKey. Both use a null-guard that prevents re-loading,
+    // so once the first call completes it is safe to run the rest in parallel.
+    final List<String> noteContentResults = [];
+    // Wait for the first readPod to complete forming the map of
+    // IndividualKeyRecord objects, one for each file
+    noteContentResults.add(await readPod(fileList.first));
+    if (fileList.length > 1) {
+      final futuresOtherNoteContentResults = [
+        for (final fileName in fileList.skip(1)) readPod(fileName),
+      ];
+      // Synchronously call readPod to return decrypted book records
+      // in turtle format
+      noteContentResults
+          .addAll(await Future.wait(futuresOtherNoteContentResults));
+    }
+
+    // List<String> noteContentResults =
+    //     await Future.wait(futuresNoteContentResult);
 
     // Retrieve note data
     for (int i = 0; i < fileList.length; i++) {
@@ -206,7 +229,9 @@ Future<NotesCallResult> getExternalNoteList({
   List<String> unparseableLogRecords = [];
 
   if (externalNotesLog.isNotEmpty) {
+    debugPrint('${externalNotesLog.keys.length} externally owned files in Pod');
     for (final fileUrl in externalNotesLog.keys) {
+      debugPrint(fileUrl);
       // Each log record of an external file
       final Map<PermissionLogLiteral, dynamic> logRecordOfFile =
           externalNotesLog[fileUrl] as Map<PermissionLogLiteral, dynamic>;
@@ -261,25 +286,44 @@ Future<NotesCallResult> getExternalNoteList({
     final List<SelectedNote> unparseableNotes = [];
     final NotesCallResult results;
 
+    // Run readPod() to fetch ttl strings of decrypted book records
+    final List<dynamic> extNoteWithContentResults =
+        List<dynamic>.filled(notes.length, null);
     if (notes.isNotEmpty) {
-      // Create a list of future functions for reading external Pods
-      List<Future<dynamic>> futuresExtNoteContentResult = [];
-      for (final note in notes) {
-        futuresExtNoteContentResult.add(
-          getExternalNoteContent(
-            note: note,
-          ),
-        );
+      // Group note indices by directory URL so that notes sharing a folder
+      // are fetched with the serial-first-then-parallel pattern (the first
+      // fetch populates that folder's IndividualKeyManager key map).
+      // Different directories are processed sequentially to ensure the key
+      // map is fully loaded before parallel reads begin within each group.
+      final Map<String, List<int>> indicesByDir = {};
+      for (int i = 0; i < notes.length; i++) {
+        final url = notes[i].noteUrl;
+        final dir = url.substring(0, url.lastIndexOf('/') + 1);
+        indicesByDir.putIfAbsent(dir, () => []).add(i);
       }
 
-      List<dynamic> extNoteWithContentResults =
-          await Future.wait(futuresExtNoteContentResult);
+      for (final indices in indicesByDir.values) {
+        // Await first note in this directory to load its key map.
+        extNoteWithContentResults[indices.first] =
+            await getExternalNoteContent(note: notes[indices.first]);
+        // Fetch remaining notes in this directory in parallel.
+        if (indices.length > 1) {
+          final remaining = await Future.wait([
+            for (final i in indices.skip(1))
+              getExternalNoteContent(note: notes[i]),
+          ]);
+          for (int j = 0; j < remaining.length; j++) {
+            extNoteWithContentResults[indices[j + 1]] = remaining[j];
+          }
+        }
+      }
 
       // Retrieve note data
       for (int i = 0; i < notes.length; i++) {
         if (extNoteWithContentResults[i] ==
             FileCallStatus.fileAccessForbidden) {
           // Files with access forbidden have note with default null content
+          // This can occur if they reference an image that was not also shared.
           fullNotes.add(notes[i]);
         } else if (extNoteWithContentResults[i] == FileCallStatus.parsingFail) {
           unparseableNotes.add(
@@ -367,8 +411,11 @@ Future<dynamic> getExternalNoteContent({
     // File does not exist on the POD
     debugPrint('Resource not found: $e');
     return FileCallStatus.fileNotExists;
-  } on Object catch (e) {
-    debugPrint('Exception details: $e');
-    rethrow;
+  } on Exception catch (e) {
+    // Includes notes that cannot be decrypted (e.g. a note with an embedded
+    // image that has not been shared — no encryption key found in either
+    // ind-keys.ttl or shared-keys.ttl).
+    debugPrint('Exception reading external note ${note.noteUrl}: $e');
+    return FileCallStatus.parsingFail;
   }
 }

--- a/lib/common/rest_api/rest_api.dart
+++ b/lib/common/rest_api/rest_api.dart
@@ -320,12 +320,19 @@ Future<NotesCallResult> getExternalNoteList({
 
       // Retrieve note data
       for (int i = 0; i < notes.length; i++) {
+        final url = notes[i].noteUrl;
+        debugPrint(
+          '${i + 1}: $url',
+        );
         if (extNoteWithContentResults[i] ==
             FileCallStatus.fileAccessForbidden) {
           // Files with access forbidden have note with default null content
           // This can occur if they reference an image that was not also shared.
+          debugPrint('accesss forbidden');
+          // Add to unparseable notes
           fullNotes.add(notes[i]);
         } else if (extNoteWithContentResults[i] == FileCallStatus.parsingFail) {
+          debugPrint('unparseable');
           unparseableNotes.add(
             SelectedNote(
               noteFileName: notes[i].noteFileName,
@@ -335,10 +342,32 @@ Future<NotesCallResult> getExternalNoteList({
           );
         } else if (extNoteWithContentResults[i] ==
             FileCallStatus.fileNotExists) {
+          debugPrint('file not exists');
           nonExistentNotes.add(notes[i]);
         } else if (extNoteWithContentResults[i] != null) {
+          debugPrint('file load successful');
           // Add note content data to note objects list
           fullNotes.add(extNoteWithContentResults[i]);
+        }
+      }
+
+      if (unparseableNotes.isEmpty && nonExistentNotes.isEmpty) {
+        debugPrint(
+          'All ${fullNotes.length.toString()} external files parsed successfully',
+        );
+      } else {
+        debugPrint(
+          '${fullNotes.length.toString()} external files parsed successfully',
+        );
+        if (unparseableNotes.isNotEmpty) {
+          debugPrint(
+            '${unparseableNotes.length.toString()} external files failed to parse.',
+          );
+        }
+        if (nonExistentNotes.isNotEmpty) {
+          debugPrint(
+            '${nonExistentNotes.length.toString()} external files did not exist.',
+          );
         }
       }
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: notepod
 description: 'Privacy preserving note taking app using PODs.'
 publish_to: 'none'
-version: 0.3.12+10
+version: 0.3.13+10
 
 environment:
   sdk: '>=3.2.3 <4.0.0'
@@ -38,7 +38,7 @@ dependency_overrides:
     # path: ../solidpod/
     git:
       url: https://github.com/anusii/solidpod.git
-      ref: dev
+      ref: jess/633_key_finding # dev
   solidui:
     # path: ../solidui/
     git:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: notepod
 description: 'Privacy preserving note taking app using PODs.'
 publish_to: 'none'
-version: 0.3.13+10
+version: 0.3.14+10
 
 environment:
   sdk: '>=3.2.3 <4.0.0'

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: notepod
-version: 0.3.12
+version: 0.3.13
 summary: Privacy preserving note taking app using PODs.
 description: |
   Notepod is a note taking app, storing your notes within your Solid

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: notepod
-version: 0.3.13
+version: 0.3.14
 summary: Privacy preserving note taking app using PODs.
 description: |
   Notepod is a note taking app, storing your notes within your Solid


### PR DESCRIPTION
## Pull Request Details

### Description
<!--- Describe the problem this PR solves -->
<!--- Describe what you have changed -->
<!--- Describe why this change is required -->

Fixes parallel decryption of lists of owner and externally owned notes. Requires parallel readPod calls to be limited to the group of notes in a folder, as each folder needs a separate awaited readPod to load the key map for that folder.

### Related Issues
<!--- If it fixes an open issue(s), please link to the issue here. -->

- issue #390 

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How To Test?
<!--- Describe the tests that a reviewer can undertake to verify your changes. -->

- Make sure you have multiple externally owned files more than one from multiple different owners.
- The load the list.
- All notes should be decrypted, except those with embedded images referencing unshared image files.

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] Screenshots included in linked issue #
- [x] Changes adhere to the [style and coding guidelines](https://survivor.togaware.com/gnulinux/flutter-style.html)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] The update contains no confidential information
- [ ] The update has no duplicated content
- [ ] No lint check errors are related to these changes (`make prep` or `flutter analyze lib`)
- [ ] Integration test `dart test` output or screenshot included in issue #
- [x] I tested the PR on these devices:
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] MacOS
  - [ ] Windows
  - [ ] Web
- [ ] I have identified reviewers
- [ ] The PR has been approved by reviewers

### Finalising
<!--- Once PR discussion is complete and reviewers have approved. -->

- [x] Merge dev into the this branch
- [x] Resolve any conflicts
- [x] Add a one line summary into the CHANGELOG.md
- [x] Push to the git repository and review
- [ ] Merge the PR into dev
