### PR TITLE
Prefer compact lists, moving meta data to popups.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,9 @@ a Pull Request. Thanks.
 
 ## 0.4
 
++ Shift metadata to available on click [0.3.20 20260427 gjw]
 + JSON import now creates the imported notes [0.3.19 20260427 gjw]
-+ Fixes to loading empty notepods [0.3.18 20260427 jesscmoore]
++ Fixes to loading empty notes [0.3.18 20260427 jesscmoore]
 + Upgrade concurrent list loading with exception handling [0.3.17 20260426 jesscmoore]
 + Add import/export of json and export to pdf and md [0.3.16 20260423 gjw]
 + Update solidpod to dev for key loading fix [0.3.15 20260418 jesscmoore]

--- a/lib/constants/ui.dart
+++ b/lib/constants/ui.dart
@@ -41,15 +41,13 @@ class NoteItemSize {
   /// modified date time are line wrapped to
   /// two lines.)
 
-  static const double compressedOwnItemHeight =
-      260; // (4 row subtitle) 190; (3 row subtitle)
+  static const double compressedOwnItemHeight = 90;
 
   /// Approximate height of uncompressed item
   /// in user's own notes list
   /// when list item text is not line wrapped.
 
-  static const double uncompressedOwnItemHeight =
-      138; // (4 row subtitle) 108; (3 row subtitle)
+  static const double uncompressedOwnItemHeight = 72;
 
   /// Approximate height of compressed item
   /// in user's external notes list
@@ -59,14 +57,13 @@ class NoteItemSize {
   /// modified date time are line wrapped to
   /// two lines.)
 
-  // static const double compressedExtItemHeight = 260; // (4 row subtitle)
-  static const double compressedExtItemHeight = 390; // (6 row subtitle)
+  static const double compressedExtItemHeight = 90;
 
   /// Approximate height of uncompressed item
   /// in user's external notes list
   /// when list item text is not line wrapped.
 
-  static const double uncompressedExtItemHeight = 207; // (6 row subtitle)
+  static const double uncompressedExtItemHeight = 72;
 
   /// Calculate card aspect ratio to use for
   /// gridview builder cards using the box

--- a/lib/notes/list_notes.dart
+++ b/lib/notes/list_notes.dart
@@ -568,9 +568,27 @@ class _ListNotesState extends State<ListNotes> {
                     padding: const EdgeInsets.all(10),
                     itemCount: _foundNotes.length,
                     itemBuilder: (context, index) => Card(
-                      child: Center(
-                        child: Container(
-                          // Show color decoration when selected
+                      child: InkWell(
+                        onTap: () {
+                          // Open note if read in permissions
+                          String access = _foundNotes[index].permissionList;
+                          if (access.contains('read')) {
+                            _scaffoldController.navigateToSubpage(
+                              ViewNote(
+                                note: _foundNotes[index],
+                                scaffoldController: _scaffoldController,
+                              ),
+                            );
+                          } else {
+                            _scaffoldController.navigateToSubpage(
+                              NonReadableNote(
+                                note: _foundNotes[index],
+                                scaffoldController: _scaffoldController,
+                              ),
+                            );
+                          }
+                        },
+                        child: Ink(
                           decoration: _foundNotes[index].isSelected
                               ? BoxDecoration(
                                   color: theme.colorScheme.onInverseSurface,
@@ -578,77 +596,66 @@ class _ListNotesState extends State<ListNotes> {
                                     Radius.circular(5),
                                   ),
                                 )
-                              : const BoxDecoration(
-                                  borderRadius:
-                                      BorderRadius.all(Radius.circular(5)),
-                                ),
-                          child: ListTile(
-                            // Select and count selected notes, including whether
-                            // an externally owned note is selected
-                            leading: SizedBox(
-                              width: NoteIconSize.width,
-                              child: Center(
-                                child: Ink(
-                                  decoration: buttonShapeList,
-                                  child: IconButton(
-                                    icon: _foundNotes[index].isSelected
-                                        ? const Icon(Icons.done)
-                                        : const Icon(Icons.edit_document),
-                                    onPressed: () {
-                                      updateSelectionMode(
-                                        _isSelectionMode,
-                                        index,
-                                      );
-                                      updateSelected(index);
-                                    },
+                              : null,
+                          child: Padding(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 16,
+                              vertical: 8,
+                            ),
+                            child: Row(
+                              crossAxisAlignment: CrossAxisAlignment.center,
+                              children: [
+                                SizedBox(
+                                  width: NoteIconSize.width,
+                                  child: Center(
+                                    child: Ink(
+                                      decoration: buttonShapeList,
+                                      child: IconButton(
+                                        icon: _foundNotes[index].isSelected
+                                            ? const Icon(Icons.done)
+                                            : const Icon(Icons.edit_document),
+                                        onPressed: () {
+                                          updateSelectionMode(
+                                            _isSelectionMode,
+                                            index,
+                                          );
+                                          updateSelected(index);
+                                        },
+                                      ),
+                                    ),
                                   ),
                                 ),
-                              ),
-                            ),
-                            // Note info
-                            title: (_foundNotes[index]
-                                    .permissionList
-                                    .contains('read'))
-                                ? Text(
-                                    _foundNotes[index].content!.noteTitle,
-                                    maxLines: (!isVeryNarrow) ? 1 : 3,
-                                    overflow: TextOverflow.ellipsis,
-                                  )
-                                : const Text(''),
-                            // Note item subtitle
-                            subtitle: NoteItemSubtitle(
-                              note: _foundNotes[index],
-                              isNarrow: isVeryNarrow,
-                            ),
-                            // Define width to avoid consuming full width
-                            trailing: SizedBox(
-                              height: 60,
-                              width: 120,
-                              child: NoteItemTrailingButtons(
-                                note: _foundNotes[index],
-                                scaffoldController: _scaffoldController,
-                              ),
-                            ),
-
-                            onTap: () {
-                              // Open note if read in permissions
-                              String access = _foundNotes[index].permissionList;
-                              if (access.contains('read')) {
-                                _scaffoldController.navigateToSubpage(
-                                  ViewNote(
+                                const SizedBox(width: 16),
+                                Expanded(
+                                  child: Column(
+                                    mainAxisSize: MainAxisSize.min,
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.start,
+                                    children: [
+                                      if (_foundNotes[index]
+                                          .permissionList
+                                          .contains('read'))
+                                        Text(
+                                          _foundNotes[index].content!.noteTitle,
+                                          maxLines: (!isVeryNarrow) ? 1 : 3,
+                                          overflow: TextOverflow.ellipsis,
+                                        ),
+                                      NoteItemSubtitle(
+                                        note: _foundNotes[index],
+                                        isNarrow: isVeryNarrow,
+                                      ),
+                                    ],
+                                  ),
+                                ),
+                                SizedBox(
+                                  width: 120,
+                                  child: NoteItemTrailingButtons(
                                     note: _foundNotes[index],
                                     scaffoldController: _scaffoldController,
                                   ),
-                                );
-                              } else {
-                                _scaffoldController.navigateToSubpage(
-                                  NonReadableNote(
-                                    note: _foundNotes[index],
-                                    scaffoldController: _scaffoldController,
-                                  ),
-                                );
-                              }
-                            },
+                                ),
+                              ],
+                            ),
                           ),
                         ),
                       ),

--- a/lib/notes/list_notes.dart
+++ b/lib/notes/list_notes.dart
@@ -23,6 +23,7 @@
 library;
 
 import 'package:flutter/material.dart';
+import 'package:markdown_tooltip/markdown_tooltip.dart';
 
 import 'package:solidui/solidui.dart';
 
@@ -608,19 +609,23 @@ class _ListNotesState extends State<ListNotes> {
                                 SizedBox(
                                   width: NoteIconSize.width,
                                   child: Center(
-                                    child: Ink(
-                                      decoration: buttonShapeList,
-                                      child: IconButton(
-                                        icon: _foundNotes[index].isSelected
-                                            ? const Icon(Icons.done)
-                                            : const Icon(Icons.edit_document),
-                                        onPressed: () {
-                                          updateSelectionMode(
-                                            _isSelectionMode,
-                                            index,
-                                          );
-                                          updateSelected(index);
-                                        },
+                                    child: MarkdownTooltip(
+                                      message:
+                                          '**Select note**\n\nTap to select this note.',
+                                      child: Ink(
+                                        decoration: buttonShapeList,
+                                        child: IconButton(
+                                          icon: _foundNotes[index].isSelected
+                                              ? const Icon(Icons.done)
+                                              : const Icon(Icons.edit_document),
+                                          onPressed: () {
+                                            updateSelectionMode(
+                                              _isSelectionMode,
+                                              index,
+                                            );
+                                            updateSelected(index);
+                                          },
+                                        ),
                                       ),
                                     ),
                                   ),

--- a/lib/notes/list_notes.dart
+++ b/lib/notes/list_notes.dart
@@ -23,8 +23,8 @@
 library;
 
 import 'package:flutter/material.dart';
-import 'package:markdown_tooltip/markdown_tooltip.dart';
 
+import 'package:markdown_tooltip/markdown_tooltip.dart';
 import 'package:solidui/solidui.dart';
 
 import 'package:notepod/constants/app.dart';

--- a/lib/notes/list_notes.dart
+++ b/lib/notes/list_notes.dart
@@ -647,12 +647,9 @@ class _ListNotesState extends State<ListNotes> {
                                     ],
                                   ),
                                 ),
-                                SizedBox(
-                                  width: 120,
-                                  child: NoteItemTrailingButtons(
-                                    note: _foundNotes[index],
-                                    scaffoldController: _scaffoldController,
-                                  ),
+                                NoteItemTrailingButtons(
+                                  note: _foundNotes[index],
+                                  scaffoldController: _scaffoldController,
                                 ),
                               ],
                             ),

--- a/lib/widgets/note_display_metadata.dart
+++ b/lib/widgets/note_display_metadata.dart
@@ -1,8 +1,8 @@
-/// A widget to display note metadata.
+/// A widget to display note metadata in a collapsible panel.
 ///
 // Time-stamp: <Friday 2025-10-14 14:59:05 +1000 Graham Williams>
 ///
-/// Copyright (C) 2025, Software Innovation Institute, ANU
+/// Copyright (C) 2025-2026, Software Innovation Institute, ANU
 ///
 /// Licensed under the GNU General Public License, Version 3 (the "License");
 ///
@@ -88,34 +88,50 @@ class DisplayNoteMetadata extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+
+    // Build the list of metadata children — same content as before.
+    final children = <Widget>[
+      if (showFileName && noteFileName.isNotEmpty)
+        ShowFilenameMetadata(filename: noteFileName),
+      if (showDates &&
+          createdDateTime.isNotEmpty &&
+          modifiedDateTime.isNotEmpty)
+        ShowDateMetadata(
+          createdDateTime: createdDateTime,
+          modifiedDateTime: modifiedDateTime,
+        ),
+      if (showSharing)
+        ShowAccessMetadata(
+          noteOwner: noteOwner,
+          permissionGranter: permissionGranter!,
+          permissionList: permissionList!,
+        ),
+      if (showPathInfo && noteUrl.isNotEmpty)
+        ShowPathMetadata(fileUrl: noteUrl),
+      const SizedBox(height: 8),
+    ];
+
+    if (children.isEmpty) return const SizedBox.shrink();
+
     return Container(
-      color: Theme.of(context).colorScheme.onInverseSurface,
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          // ShowFileName
-          if (showFileName && noteFileName.isNotEmpty)
-            ShowFilenameMetadata(filename: noteFileName),
-          // ShowDates (created and modified)
-          if (showDates &&
-              createdDateTime.isNotEmpty &&
-              modifiedDateTime.isNotEmpty)
-            ShowDateMetadata(
-              createdDateTime: createdDateTime,
-              modifiedDateTime: modifiedDateTime,
-            ),
-          // Show sharing info (owner, provider, access list)
-          if (showSharing)
-            ShowAccessMetadata(
-              noteOwner: noteOwner,
-              permissionGranter: permissionGranter!,
-              permissionList: permissionList!,
-            ),
-          // Show path info (filename and path)
-          if (showPathInfo && noteUrl != '') ShowPathMetadata(fileUrl: noteUrl),
-          const SizedBox(height: 10),
-        ],
+      color: cs.onInverseSurface,
+      child: ExpansionTile(
+        initiallyExpanded: false,
+        tilePadding: const EdgeInsets.symmetric(horizontal: 15),
+        leading: Icon(
+          Icons.info_outline,
+          size: 18,
+          color: cs.onSurfaceVariant,
+        ),
+        title: Text(
+          'Note details',
+          style: TextStyle(
+            fontSize: 13,
+            color: cs.onSurfaceVariant,
+          ),
+        ),
+        children: children,
       ),
     );
   }

--- a/lib/widgets/note_item_subtitle.dart
+++ b/lib/widgets/note_item_subtitle.dart
@@ -86,27 +86,27 @@ class NoteItemSubtitle extends StatelessWidget {
           width: 480,
           child: SingleChildScrollView(
             child: Table(
-            columnWidths: const {
-              0: IntrinsicColumnWidth(),
-              1: FlexColumnWidth(),
-            },
-            children: rows.map((r) {
-              return TableRow(
-                children: [
-                  Padding(
-                    padding: const EdgeInsets.fromLTRB(0, 4, 16, 4),
-                    child: Text(
-                      r.label,
-                      style: const TextStyle(fontWeight: FontWeight.bold),
+              columnWidths: const {
+                0: IntrinsicColumnWidth(),
+                1: FlexColumnWidth(),
+              },
+              children: rows.map((r) {
+                return TableRow(
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(0, 4, 16, 4),
+                      child: Text(
+                        r.label,
+                        style: const TextStyle(fontWeight: FontWeight.bold),
+                      ),
                     ),
-                  ),
-                  Padding(
-                    padding: const EdgeInsets.symmetric(vertical: 4),
-                    child: Text(r.value),
-                  ),
-                ],
-              );
-            }).toList(),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 4),
+                      child: Text(r.value),
+                    ),
+                  ],
+                );
+              }).toList(),
             ),
           ),
         ),

--- a/lib/widgets/note_item_subtitle.dart
+++ b/lib/widgets/note_item_subtitle.dart
@@ -24,6 +24,8 @@ library;
 
 import 'package:flutter/material.dart';
 
+import 'package:markdown_tooltip/markdown_tooltip.dart';
+
 import 'package:notepod/models/note.dart';
 import 'package:notepod/utils/get_id.dart';
 import 'package:notepod/utils/misc.dart';
@@ -48,31 +50,112 @@ class NoteItemSubtitle extends StatelessWidget {
         _isNarrow = isNarrow;
 
   final Note _note;
+
+  // ignore: unused_field
   final bool _isNarrow;
+
+  void _showMetadata(BuildContext context) {
+    final n = _note;
+    final rows = <_Row>[];
+
+    rows.add(_Row('File', n.noteFileName));
+    if (n.content != null) {
+      rows.add(_Row('Created', getDateTimeStr(n.content!.createdDateTime)));
+      rows.add(_Row('Modified', getDateTimeStr(n.content!.modifiedDateTime)));
+    }
+    rows.add(_Row('Owner', getId(n.noteOwner)));
+    if (!n.isExternalRes && n.authUserList != null) {
+      rows.add(
+        _Row('Shared with', getRecipNbrStr(n.authUserList!.keys.length)),
+      );
+    }
+    if (n.isExternalRes) {
+      rows.add(_Row('Shared by', getId(n.permissionGranter ?? 'N/A')));
+    }
+    rows.add(_Row('Permissions', n.permissionList));
+
+    showDialog<void>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(
+          n.content?.noteTitle ?? n.noteFileName,
+          maxLines: 2,
+          overflow: TextOverflow.ellipsis,
+        ),
+        content: SizedBox(
+          width: 480,
+          child: SingleChildScrollView(
+            child: Table(
+            columnWidths: const {
+              0: IntrinsicColumnWidth(),
+              1: FlexColumnWidth(),
+            },
+            children: rows.map((r) {
+              return TableRow(
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(0, 4, 16, 4),
+                    child: Text(
+                      r.label,
+                      style: const TextStyle(fontWeight: FontWeight.bold),
+                    ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 4),
+                    child: Text(r.value),
+                  ),
+                ],
+              );
+            }).toList(),
+            ),
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: const Text('Close'),
+          ),
+        ],
+      ),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
-    return Text(
-      (!_note.isExternalRes)
-          ? 'Filename: ${_note.noteFileName} \n'
-              'Created on: ${getDateTimeStr(_note.content!.createdDateTime)} \n'
-              'Last modified: ${getDateTimeStr(_note.content!.modifiedDateTime)}\n'
-              'Owner: ${getId(_note.noteOwner)} \n'
-              'Shared with: ${getRecipNbrStr(_note.authUserList!.keys.length)} \n'
-              'Permissions: ${_note.permissionList}'
-          : (_note.permissionList.contains('read'))
-              ? 'Filename: ${_note.noteFileName} \n'
-                  'Created on: ${getDateTimeStr(_note.content!.createdDateTime)} \n'
-                  'Last modified: ${getDateTimeStr(_note.content!.modifiedDateTime)}\n'
-                  'Owner: ${getId(_note.noteOwner)} \n'
-                  'Shared by: ${getId(_note.permissionGranter ?? 'N/A')} \n'
-                  'Permissions: ${_note.permissionList}'
-              : 'Filename: ${_note.noteFileName} \n'
-                  'Owner: ${getId(_note.noteOwner)} \n'
-                  'Shared by: ${getId(_note.permissionGranter ?? 'N/A')} \n'
-                  'Permissions: ${_note.permissionList}',
-      maxLines: (!_isNarrow) ? 6 : 12, // Limit lines
-      overflow: TextOverflow.ellipsis,
+    final cs = Theme.of(context).colorScheme;
+    final modified = _note.content != null
+        ? getDateTimeStr(_note.content!.modifiedDateTime)
+        : '';
+    return Row(
+      children: [
+        if (modified.isNotEmpty)
+          Expanded(
+            child: Text(
+              modified,
+              style: TextStyle(fontSize: 12, color: cs.onSurfaceVariant),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        MarkdownTooltip(
+          message: '**Note details**\n\nTap to view metadata for this note.',
+          child: IconButton(
+            icon: Icon(
+              Icons.info_outline,
+              size: 16,
+              color: cs.onSurfaceVariant.withValues(alpha: 0.6),
+            ),
+            padding: EdgeInsets.zero,
+            constraints: const BoxConstraints(),
+            onPressed: () => _showMetadata(context),
+          ),
+        ),
+      ],
     );
   }
+}
+
+class _Row {
+  final String label;
+  final String value;
+  const _Row(this.label, this.value);
 }

--- a/lib/widgets/note_item_subtitle.dart
+++ b/lib/widgets/note_item_subtitle.dart
@@ -24,17 +24,11 @@ library;
 
 import 'package:flutter/material.dart';
 
-import 'package:markdown_tooltip/markdown_tooltip.dart';
-
 import 'package:notepod/models/note.dart';
-import 'package:notepod/utils/get_id.dart';
 import 'package:notepod/utils/misc.dart';
 
 /// A [stateless] widget to show subtitle of a note list item.
-/// It shows the number of recipients that the note is shared
-/// with if note owned by user, or entity that share it if
-/// owned by another, and does not show encrypted content if
-/// read access denied.
+/// Shows the last modified date, or nothing if unavailable.
 ///
 /// Arguments:
 /// - [note] - A note.
@@ -54,108 +48,17 @@ class NoteItemSubtitle extends StatelessWidget {
   // ignore: unused_field
   final bool _isNarrow;
 
-  void _showMetadata(BuildContext context) {
-    final n = _note;
-    final rows = <_Row>[];
-
-    rows.add(_Row('File', n.noteFileName));
-    if (n.content != null) {
-      rows.add(_Row('Created', getDateTimeStr(n.content!.createdDateTime)));
-      rows.add(_Row('Modified', getDateTimeStr(n.content!.modifiedDateTime)));
-    }
-    rows.add(_Row('Owner', getId(n.noteOwner)));
-    if (!n.isExternalRes && n.authUserList != null) {
-      rows.add(
-        _Row('Shared with', getRecipNbrStr(n.authUserList!.keys.length)),
-      );
-    }
-    if (n.isExternalRes) {
-      rows.add(_Row('Shared by', getId(n.permissionGranter ?? 'N/A')));
-    }
-    rows.add(_Row('Permissions', n.permissionList));
-
-    showDialog<void>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: Text(
-          n.content?.noteTitle ?? n.noteFileName,
-          maxLines: 2,
-          overflow: TextOverflow.ellipsis,
-        ),
-        content: SizedBox(
-          width: 480,
-          child: SingleChildScrollView(
-            child: Table(
-              columnWidths: const {
-                0: IntrinsicColumnWidth(),
-                1: FlexColumnWidth(),
-              },
-              children: rows.map((r) {
-                return TableRow(
-                  children: [
-                    Padding(
-                      padding: const EdgeInsets.fromLTRB(0, 4, 16, 4),
-                      child: Text(
-                        r.label,
-                        style: const TextStyle(fontWeight: FontWeight.bold),
-                      ),
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.symmetric(vertical: 4),
-                      child: Text(r.value),
-                    ),
-                  ],
-                );
-              }).toList(),
-            ),
-          ),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(ctx),
-            child: const Text('Close'),
-          ),
-        ],
-      ),
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     final cs = Theme.of(context).colorScheme;
     final modified = _note.content != null
         ? getDateTimeStr(_note.content!.modifiedDateTime)
         : '';
-    return Row(
-      children: [
-        if (modified.isNotEmpty)
-          Expanded(
-            child: Text(
-              modified,
-              style: TextStyle(fontSize: 12, color: cs.onSurfaceVariant),
-              overflow: TextOverflow.ellipsis,
-            ),
-          ),
-        MarkdownTooltip(
-          message: '**Note details**\n\nTap to view metadata for this note.',
-          child: IconButton(
-            icon: Icon(
-              Icons.info_outline,
-              size: 16,
-              color: cs.onSurfaceVariant.withValues(alpha: 0.6),
-            ),
-            padding: EdgeInsets.zero,
-            constraints: const BoxConstraints(),
-            onPressed: () => _showMetadata(context),
-          ),
-        ),
-      ],
+    if (modified.isEmpty) return const SizedBox.shrink();
+    return Text(
+      modified,
+      style: TextStyle(fontSize: 12, color: cs.onSurfaceVariant),
+      overflow: TextOverflow.ellipsis,
     );
   }
-}
-
-class _Row {
-  final String label;
-  final String value;
-  const _Row(this.label, this.value);
 }

--- a/lib/widgets/note_item_trailing_buttons.dart
+++ b/lib/widgets/note_item_trailing_buttons.dart
@@ -23,8 +23,8 @@
 library;
 
 import 'package:flutter/material.dart';
-import 'package:markdown_tooltip/markdown_tooltip.dart';
 
+import 'package:markdown_tooltip/markdown_tooltip.dart';
 import 'package:solidui/solidui.dart';
 
 import 'package:notepod/models/note.dart';

--- a/lib/widgets/note_item_trailing_buttons.dart
+++ b/lib/widgets/note_item_trailing_buttons.dart
@@ -124,7 +124,7 @@ class NoteItemTrailingButtons extends StatelessWidget {
 
     return Row(
       mainAxisSize: MainAxisSize.min,
-      spacing: 5.0,
+      spacing: 8.0,
       children: [
         // Info button — leftmost, opens metadata dialog
         MarkdownTooltip(

--- a/lib/widgets/note_item_trailing_buttons.dart
+++ b/lib/widgets/note_item_trailing_buttons.dart
@@ -24,11 +24,14 @@ library;
 
 import 'package:flutter/material.dart';
 
+import 'package:markdown_tooltip/markdown_tooltip.dart';
 import 'package:solidui/solidui.dart';
 
 import 'package:notepod/models/note.dart';
 import 'package:notepod/notes/list_notes_screen.dart';
 import 'package:notepod/notes/share_note.dart';
+import 'package:notepod/utils/get_id.dart';
+import 'package:notepod/utils/misc.dart';
 import 'package:notepod/widgets/simple_action_button.dart';
 
 /// A [stateless] widget to show trailing buttons in a note
@@ -49,14 +52,95 @@ class NoteItemTrailingButtons extends StatelessWidget {
   final Note _note;
   final SolidScaffoldController _scaffoldController;
 
+  void _showMetadata(BuildContext context) {
+    final n = _note;
+    final rows = <_Row>[];
+
+    rows.add(_Row('File', n.noteFileName));
+    if (n.content != null) {
+      rows.add(_Row('Created', getDateTimeStr(n.content!.createdDateTime)));
+      rows.add(_Row('Modified', getDateTimeStr(n.content!.modifiedDateTime)));
+    }
+    rows.add(_Row('Owner', getId(n.noteOwner)));
+    if (!n.isExternalRes && n.authUserList != null) {
+      rows.add(
+        _Row('Shared with', getRecipNbrStr(n.authUserList!.keys.length)),
+      );
+    }
+    if (n.isExternalRes) {
+      rows.add(_Row('Shared by', getId(n.permissionGranter ?? 'N/A')));
+    }
+    rows.add(_Row('Permissions', n.permissionList));
+
+    showDialog<void>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(
+          n.content?.noteTitle ?? n.noteFileName,
+          maxLines: 2,
+          overflow: TextOverflow.ellipsis,
+        ),
+        content: SizedBox(
+          width: 480,
+          child: SingleChildScrollView(
+            child: Table(
+              columnWidths: const {
+                0: IntrinsicColumnWidth(),
+                1: FlexColumnWidth(),
+              },
+              children: rows.map((r) {
+                return TableRow(
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(0, 4, 16, 4),
+                      child: Text(
+                        r.label,
+                        style: const TextStyle(fontWeight: FontWeight.bold),
+                      ),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 4),
+                      child: Text(r.value),
+                    ),
+                  ],
+                );
+              }).toList(),
+            ),
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: const Text('Close'),
+          ),
+        ],
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
     List accessList = _note.permissionList.split(',');
 
     return Row(
       mainAxisAlignment: MainAxisAlignment.end,
       spacing: 5.0,
       children: [
+        // Info button — leftmost, opens metadata dialog
+        MarkdownTooltip(
+          message: '**Note details**\n\nTap to view metadata for this note.',
+          child: IconButton(
+            icon: Icon(
+              Icons.info_outline,
+              size: 16,
+              color: cs.onSurfaceVariant.withValues(alpha: 0.6),
+            ),
+            padding: EdgeInsets.zero,
+            constraints: const BoxConstraints(),
+            onPressed: () => _showMetadata(context),
+          ),
+        ),
         // Share button if control in permissions
         if (accessList.contains('control')) ...[
           SimpleActionButton(
@@ -78,4 +162,10 @@ class NoteItemTrailingButtons extends StatelessWidget {
       ],
     );
   }
+}
+
+class _Row {
+  final String label;
+  final String value;
+  const _Row(this.label, this.value);
 }

--- a/lib/widgets/note_item_trailing_buttons.dart
+++ b/lib/widgets/note_item_trailing_buttons.dart
@@ -23,8 +23,8 @@
 library;
 
 import 'package:flutter/material.dart';
-
 import 'package:markdown_tooltip/markdown_tooltip.dart';
+
 import 'package:solidui/solidui.dart';
 
 import 'package:notepod/models/note.dart';
@@ -120,41 +120,38 @@ class NoteItemTrailingButtons extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
     List accessList = _note.permissionList.split(',');
 
     return Row(
-      mainAxisAlignment: MainAxisAlignment.end,
+      mainAxisSize: MainAxisSize.min,
       spacing: 5.0,
       children: [
         // Info button — leftmost, opens metadata dialog
         MarkdownTooltip(
           message: '**Note details**\n\nTap to view metadata for this note.',
-          child: IconButton(
-            icon: Icon(
-              Icons.info_outline,
-              size: 16,
-              color: cs.onSurfaceVariant.withValues(alpha: 0.6),
-            ),
-            padding: EdgeInsets.zero,
-            constraints: const BoxConstraints(),
+          child: SimpleActionButton(
+            icon: const Icon(Icons.info_outline),
             onPressed: () => _showMetadata(context),
           ),
         ),
+
         // Share button if control in permissions
         if (accessList.contains('control')) ...[
-          SimpleActionButton(
-            icon: const Icon(Icons.share),
-            childPage: ShareNote(
-              noteUrl: _note.noteUrl,
-              noteOwner: _note.noteOwner,
-              isExternal: _note.isExternalRes,
-              backPage: ListNotesScreen(
+          MarkdownTooltip(
+            message: '**Share note**\n\nTap to share this note.',
+            child: SimpleActionButton(
+              icon: const Icon(Icons.share),
+              childPage: ShareNote(
+                noteUrl: _note.noteUrl,
+                noteOwner: _note.noteOwner,
+                isExternal: _note.isExternalRes,
+                backPage: ListNotesScreen(
+                  scaffoldController: _scaffoldController,
+                ),
                 scaffoldController: _scaffoldController,
               ),
               scaffoldController: _scaffoldController,
             ),
-            scaffoldController: _scaffoldController,
           ),
         ],
         // Open note icon

--- a/lib/widgets/simple_action_button.dart
+++ b/lib/widgets/simple_action_button.dart
@@ -36,8 +36,10 @@ import 'package:notepod/constants/colours.dart';
 ///
 /// Arguments:
 /// - [icon] - icon to show on button.
-/// - [childPage] - child page to navigate to.
-/// - [scaffoldController] - Controller for the Solid scaffold.
+/// - [onPressed] - callback to invoke on press. When provided, [childPage]
+///   and [scaffoldController] are not required.
+/// - [childPage] - child page to navigate to (required when [onPressed] is null).
+/// - [scaffoldController] - Controller for the Solid scaffold (required when [onPressed] is null).
 /// - [backgroundColor] - set button background color. (Default: grey [ButtonBackgroundColor.def]).
 /// - [foregroundColor] - set button foreground color. (Default [ButtonForegroundColor.white]).
 
@@ -45,11 +47,14 @@ class SimpleActionButton extends StatelessWidget {
   /// Button icon
   final Icon icon;
 
-  /// Childpage
-  final Widget childPage;
+  /// Optional press callback. When set, overrides childPage navigation.
+  final VoidCallback? onPressed;
 
-  /// Solid Scaffold Controller
-  final SolidScaffoldController scaffoldController;
+  /// Childpage (required when [onPressed] is null)
+  final Widget? childPage;
+
+  /// Solid Scaffold Controller (required when [onPressed] is null)
+  final SolidScaffoldController? scaffoldController;
 
   /// Button background color
   final Color backgroundColor;
@@ -60,13 +65,18 @@ class SimpleActionButton extends StatelessWidget {
   const SimpleActionButton({
     super.key,
     required this.icon,
-    required this.childPage,
-    required this.scaffoldController,
+    this.onPressed,
+    this.childPage,
+    this.scaffoldController,
     this.backgroundColor = ButtonBackgroundColor.def,
     // When SimpleActionButton called independently, default foreground color
     // is ButtonForegroundColor.list
     this.foregroundColor = ButtonForegroundColor.list,
-  });
+  }) : assert(
+          onPressed != null ||
+              (childPage != null && scaffoldController != null),
+          'Provide onPressed, or both childPage and scaffoldController.',
+        );
 
   @override
   Widget build(BuildContext context) {
@@ -79,10 +89,10 @@ class SimpleActionButton extends StatelessWidget {
         child: IconButton(
           color: foregroundColor,
           icon: icon,
-          onPressed: () async {
-            // Redirect.
-            scaffoldController.navigateToSubpage(childPage);
-          },
+          onPressed: onPressed ??
+              () async {
+                scaffoldController!.navigateToSubpage(childPage!);
+              },
         ),
       ),
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: notepod
 description: 'Privacy preserving note taking app using PODs.'
 publish_to: 'none'
-version: 0.3.19+11
+version: 0.3.20+11
 
 environment:
   sdk: '>=3.2.3 <4.0.0'

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: notepod
-version: 0.3.19
+version: 0.3.20
 summary: Privacy preserving note taking app using PODs.
 description: |
   Notepod is a note taking app, storing your notes within your Solid


### PR DESCRIPTION
## Pull Request Details

### Description

I was finding the mass of meta data was distracting me from the notes.

The notes list is now two lines per note with a INFO button used to popup the useful meta data.

<img width="902" height="819" alt="image" src="https://github.com/user-attachments/assets/e3f12c59-1a53-41e1-ac12-3ede9ad4e22b" />

<img width="902" height="819" alt="image" src="https://github.com/user-attachments/assets/e7827b0c-dda5-47a5-8340-0e584c557ac4" />

The note display similarly hides the meta data by default but it is available when requested. 

<img width="902" height="819" alt="image" src="https://github.com/user-attachments/assets/e155e4ab-1e1f-4af2-97e8-db51c5eb5318" />

<img width="902" height="819" alt="image" src="https://github.com/user-attachments/assets/6d7cadc5-5b39-4ec9-929b-44fe990fafe6" />



### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How To Test?

Load the app, note the compact list view, tap INFO to popup meta data, tap the item to display the note, tap the INFO to roll down the meta data.

### Checklist

- [X] Screenshots included above
- [X] Changes adhere to the [style and coding guidelines](https://survivor.togaware.com/gnulinux/flutter-style.html)
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] The update contains no confidential information
- [X] The update has no duplicated content
- [X] No lint check errors are related to these changes (`make prep` or `flutter analyze lib`)
- [ ] Integration test `dart test` output or screenshot included in issue #
- [x] I tested the PR on these devices:
  - [ ] Android
  - [x] iOS
  - [X] Linux
  - [x] MacOS
  - [ ] Windows
  - [ ] Web
- [X] I have identified reviewers
- [ ] The PR has been approved by reviewers

### Finalising
<!--- Once PR discussion is complete and reviewers have approved. -->

- [x] Merge dev into the this branch
- [x] Resolve any conflicts
- [x] Add a one line summary into the CHANGELOG.md
- [x] Push to the git repository and review
- [x] Merge the PR into dev
